### PR TITLE
fix findings L-2, L-3, L-4, L-5, L-6, G-5, M-1

### DIFF
--- a/contracts/core/DebtToken.sol
+++ b/contracts/core/DebtToken.sol
@@ -18,6 +18,7 @@ contract DebtToken is OFT {
     // --- ERC 3156 Data ---
     bytes32 private constant _RETURN_VALUE = keccak256("ERC3156FlashBorrower.onFlashLoan");
     uint256 public constant FLASH_LOAN_FEE = 9; // 1 = 0.0001%
+    uint256 public constant MIN_FLASH_LOAN = 1112;
 
     // --- Data for EIP2612 ---
 
@@ -166,6 +167,7 @@ contract DebtToken is OFT {
      * @return The fees applied to the corresponding flash loan.
      */
     function _flashFee(uint256 amount) internal pure returns (uint256) {
+        require(amount >= MIN_FLASH_LOAN, "ERC20FlashMint: amount too small");
         return (amount * FLASH_LOAN_FEE) / 10000;
     }
 

--- a/contracts/core/DebtToken.sol
+++ b/contracts/core/DebtToken.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-// import { OFT, IERC20, ERC20 } from "@layerzerolabs/solidity-examples/contracts/token/oft/OFT.sol";
-import { OFT, IERC20, ERC20 } from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/OFT.sol";
-import { IERC3156FlashBorrower } from "@openzeppelin/contracts/interfaces/IERC3156FlashBorrower.sol";
+import {OFT, IERC20, ERC20} from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/OFT.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {IERC3156FlashBorrower} from "@openzeppelin/contracts/interfaces/IERC3156FlashBorrower.sol";
 import {IBabelCore} from "../interfaces/IBabelCore.sol";
 
 /**
@@ -234,7 +234,7 @@ contract DebtToken is OFT {
                 keccak256(abi.encode(permitTypeHash, owner, spender, amount, _nonces[owner]++, deadline))
             )
         );
-        address recoveredAddress = ecrecover(digest, v, r, s);
+        address recoveredAddress = ECDSA.recover(digest, v, r, s);
         require(recoveredAddress == owner, "Debt: invalid signature");
         _approve(owner, spender, amount);
     }

--- a/contracts/core/DebtToken.sol
+++ b/contracts/core/DebtToken.sol
@@ -17,7 +17,7 @@ contract DebtToken is OFT {
 
     // --- ERC 3156 Data ---
     bytes32 private constant _RETURN_VALUE = keccak256("ERC3156FlashBorrower.onFlashLoan");
-    uint256 public constant FLASH_LOAN_FEE = 9; // 1 = 0.0001%
+    uint256 public constant FLASH_LOAN_FEE = 9; // 1 = 0.01%
 
     // --- Data for EIP2612 ---
 

--- a/contracts/core/DebtToken.sol
+++ b/contracts/core/DebtToken.sol
@@ -18,7 +18,6 @@ contract DebtToken is OFT {
     // --- ERC 3156 Data ---
     bytes32 private constant _RETURN_VALUE = keccak256("ERC3156FlashBorrower.onFlashLoan");
     uint256 public constant FLASH_LOAN_FEE = 9; // 1 = 0.0001%
-    uint256 public constant MIN_FLASH_LOAN = 1112;
 
     // --- Data for EIP2612 ---
 
@@ -164,11 +163,11 @@ contract DebtToken is OFT {
      * implementation has 0 fees. This function can be overloaded to make
      * the flash loan mechanism deflationary.
      * @param amount The amount of tokens to be loaned.
-     * @return The fees applied to the corresponding flash loan.
+     * @return fee applied to the corresponding flash loan.
      */
-    function _flashFee(uint256 amount) internal pure returns (uint256) {
-        require(amount >= MIN_FLASH_LOAN, "ERC20FlashMint: amount too small");
-        return (amount * FLASH_LOAN_FEE) / 10000;
+    function _flashFee(uint256 amount) internal pure returns (uint256 fee) {
+        fee = (amount * FLASH_LOAN_FEE) / 10000;
+        require(fee > 0, "ERC20FlashMint: amount too small");
     }
 
     /**

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -343,7 +343,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         babelCore.acceptTransferOwnership();
     }
 
-    function _containsSetGuardianPayload(uint256 payloadLength, Action[] memory payload) internal view returns (bool) {
+    function _containsSetGuardianPayload(uint256 payloadLength, Action[] memory payload) internal pure returns (bool) {
         for(uint256 i; i<payloadLength; i++) {
             bytes memory data = payload[i].data;
 

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -7,6 +7,8 @@ import {SystemStart} from "../dependencies/SystemStart.sol";
 import {ITokenLocker} from "../interfaces/ITokenLocker.sol";
 import {IBabelCore} from "../interfaces/IBabelCore.sol";
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 /**
     @title Babel DAO Admin Voter
     @notice Primary ownership contract for all Babel contracts. Allows executing
@@ -240,7 +242,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         uint256 totalWeight = tokenLocker.getTotalWeightAt(week);
 
         // calculate required quorum for the proposal to pass
-        uint40 requiredWeight = uint40((totalWeight * proposalPassPct) / MAX_PCT);
+        uint40 requiredWeight = SafeCast.toUint40((totalWeight * proposalPassPct) / MAX_PCT);
 
         // output newly created proposal id
         proposalId = proposalData.length;
@@ -248,7 +250,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         // save proposal data
         proposalData.push(
             Proposal({
-                week: uint16(week),
+                week: SafeCast.toUint16(week),
                 createdAt: uint32(block.timestamp),
                 canExecuteAfter: 0,
                 currentWeight: 0,
@@ -311,7 +313,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         accountVoteWeights[account][id] = weight;
 
         // calculate proposal's accumulated voting weight
-        uint40 updatedWeight = uint40(proposal.currentWeight + weight);
+        uint40 updatedWeight = SafeCast.toUint40(proposal.currentWeight + weight);
 
         // update proposal's accumulated voting weight
         proposalData[id].currentWeight = updatedWeight;

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -289,7 +289,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         // prevent voting if proposal has been cancelled or executed
         require(!proposal.processed, "Proposal already processed");
 
-        // prevent voting outside the allowing voting window
+        // prevent voting outside the allowed voting window
         require(proposal.createdAt + VOTING_PERIOD > block.timestamp, "Voting period has closed");
 
         // fetch account's voting weight during the proposal's week

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -95,7 +95,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         return proposalData.length;
     }
 
-    function minCreateProposalWeight() public view returns (uint256 weight) {
+    function minCreateProposalWeight() external view returns (uint256 weight) {
         // store getWeek() directly into output `weight` return
         weight = getWeek();
 

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -187,6 +187,11 @@ contract AdminVoting is DelegatedOps, SystemStart {
     function getProposalPayload(uint256 id) external view returns(Action[] memory) {
         return proposalPayloads[id];
     }
+    function getProposalPassed(uint256 id) external view returns(bool) {
+        Proposal memory proposal = proposalData[id];
+        return proposal.currentWeight >= proposal.requiredWeight;
+    }
+
 
     /**
         @notice Create a new proposal

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -301,7 +301,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
 
             // enforce minimum weight > 0 to vote
             require(weight > 0, "No vote weight");
-        // otherwise if account specific an exact voting weight > 0 then
+        // otherwise if account specified an exact voting weight > 0 then
         // enforce it is <= their max voting weight
         } else {
             require(weight <= accountWeight, "Weight exceeds account weight");

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -101,6 +101,8 @@ contract AdminVoting is DelegatedOps, SystemStart {
         week -= 1;
 
         uint256 totalWeight = tokenLocker.getTotalWeightAt(week);
+        require(totalWeight > 0, "Zero total voting weight for given week");
+
         return (totalWeight * minCreateProposalPct) / MAX_PCT;
     }
 

--- a/contracts/dao/BabelToken.sol
+++ b/contracts/dao/BabelToken.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 import {IERC2612} from "../interfaces/IERC2612.sol";
 import {OFT, IERC20, ERC20} from "@layerzerolabs/solidity-examples/contracts/token/oft/v1/OFT.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 /**
     @title Babel Governance Token
     @notice Given as an incentive for users of the protocol. Can be locked in `TokenLocker`
@@ -89,7 +90,7 @@ contract BabelToken is OFT, IERC2612 {
                 keccak256(abi.encode(permitTypeHash, owner, spender, amount, _nonces[owner]++, deadline))
             )
         );
-        address recoveredAddress = ecrecover(digest, v, r, s);
+        address recoveredAddress = ECDSA.recover(digest, v, r, s);
         require(recoveredAddress == owner, "BABEL: invalid signature");
         _approve(owner, spender, amount);
     }

--- a/contracts/dao/TokenLocker.sol
+++ b/contracts/dao/TokenLocker.sol
@@ -148,7 +148,6 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
                 }
             }
         }
-        return (locked, unlocked);
     }
 
     /**
@@ -161,7 +160,7 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
     /**
         @notice Get the lock weight for an account in a given week
      */
-    function getAccountWeightAt(address account, uint256 week) public view returns (uint256) {
+    function getAccountWeightAt(address account, uint256 week) public view returns (uint256 weight) {
         if (week > getWeek()) return 0;
         uint32[65535] storage weeklyUnlocks = accountWeeklyUnlocks[account];
         uint40[65535] storage weeklyWeights = accountWeeklyWeights[account];
@@ -171,7 +170,8 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
         if (accountWeek >= week) return weeklyWeights[week];
 
         uint256 locked = accountData.locked;
-        uint256 weight = weeklyWeights[accountWeek];
+        weight = weeklyWeights[accountWeek];
+        
         if (locked == 0 || accountData.frozen > 0) {
             return weight;
         }
@@ -191,7 +191,6 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
                 if (locked == 0) break;
             }
         }
-        return weight;
     }
 
     /**
@@ -240,7 +239,6 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
                 lockData[i] = LockData({ weeksToUnlock: idx - systemWeek, amount: unlocks[idx] });
             }
         }
-        return (lockData, frozenAmount);
     }
 
     /**
@@ -315,7 +313,6 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
             }
         }
         amountToWithdraw -= remaining;
-        return (amountToWithdraw, penaltyTotal);
     }
 
     /**
@@ -328,7 +325,7 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
     /**
         @notice Get the total lock weight for a given week
      */
-    function getTotalWeightAt(uint256 week) public view returns (uint256) {
+    function getTotalWeightAt(uint256 week) public view returns (uint256 weight) {
         uint256 systemWeek = getWeek();
         if (week > systemWeek) return 0;
 
@@ -336,7 +333,7 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
         if (week <= updatedWeek) return totalWeeklyWeights[week];
 
         uint32 rate = totalDecayRate;
-        uint40 weight = totalWeeklyWeights[updatedWeek];
+        weight = totalWeeklyWeights[updatedWeek];
         if (rate == 0 || updatedWeek >= systemWeek) {
             return weight;
         }
@@ -346,7 +343,6 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
             weight -= rate;
             rate -= totalWeeklyUnlocks[updatedWeek];
         }
-        return weight;
     }
 
     /**
@@ -924,6 +920,5 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
         accountData.unlocked = uint32(accountData.unlocked + unlocked);
         accountData.locked = uint32(locked);
         accountData.week = uint16(accountWeek);
-        return weight;
     }
 }

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -100,6 +100,10 @@ contract BabelVault is IBabelVault, BabelOwnable, SystemStart {
         uint128[] memory _fixedInitialAmounts,
         InitialAllowance[] memory initialAllowances
     ) external {
+        // enforce invariant described in TokenLocker to prevent overflows
+        require(totalSupply <= type(uint32).max * locker.lockToTokenRatio(), 
+                "Total supply must be <= type(uint32).max * lockToTokenRatio");
+
         require(msg.sender == deploymentManager, "!deploymentManager");
         emissionSchedule = _emissionSchedule;
         boostCalculator = _boostCalculator;

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,3 +4,6 @@ out = 'out'
 libs = ['node_modules', 'lib']
 test = 'test'
 cache_path  = 'cache_forge'
+
+[fuzz]
+runs = 1000

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -305,5 +305,8 @@ contract TestSetup is Test {
         // approve BorrowerOperations for 50 StakedBTC tokens
         // stakedBTC.approve(addresses.borrowerOps, 50e18);
         vm.stopPrank();
+
+        // verify we are in the first week
+        assertEq(tokenLocker.getWeek(), 0);
     }
 }

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -104,7 +104,7 @@ contract TestSetup is Test {
     uint64 internal constant INIT_ES_LOCK_DECAY_WEEKS = 1;
     uint64 internal constant INIT_ES_WEEKLY_PCT = 2500; // 25%
     uint64[2][] internal scheduledWeeklyPct;
-    uint256 internal constant INIT_BAB_TKN_TOTAL_SUPPLY = 1_000_000e18;
+    uint256 internal constant INIT_BAB_TKN_TOTAL_SUPPLY = type(uint32).max;
     uint64 internal constant INIT_VLT_LOCK_WEEKS = 2;
 
 

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -96,7 +96,7 @@ contract TestSetup is Test {
     // constants
     uint256 internal constant INIT_GAS_COMPENSATION = 200e18;
     uint256 internal constant INIT_MIN_NET_DEBT = 1800e18;
-    uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1;
+    uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1e18;
     address internal constant ZERO_ADDRESS = address(0);
 
     uint256 internal constant INIT_BS_GRACE_WEEKS = 1;
@@ -104,7 +104,7 @@ contract TestSetup is Test {
     uint64 internal constant INIT_ES_LOCK_DECAY_WEEKS = 1;
     uint64 internal constant INIT_ES_WEEKLY_PCT = 2500; // 25%
     uint64[2][] internal scheduledWeeklyPct;
-    uint256 internal constant INIT_BAB_TKN_TOTAL_SUPPLY = type(uint32).max;
+    uint256 internal constant INIT_BAB_TKN_TOTAL_SUPPLY = type(uint32).max*INIT_LOCK_TO_TOKEN_RATIO;
     uint64 internal constant INIT_VLT_LOCK_WEEKS = 2;
 
 

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -95,6 +95,10 @@ contract TestSetup is Test {
 
 
     function setUp() public virtual {
+        // prevent Foundry from setting block.timestamp = 1 which can cause
+        // errors in this protocol
+        vm.warp(1659973223);
+
         // set addresses used by tests
         users.owner = address(0x1111);
         users.guardian = address(0x2222);

--- a/test/foundry/core/DebtTokenTest.t.sol
+++ b/test/foundry/core/DebtTokenTest.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup, DebtToken} from "../TestSetup.sol";
+
+contract DebtTokenTest is TestSetup {
+
+    function test_flashLoanFee() external {
+        // entire supply initially available to borrow
+        assertEq(debtToken.maxFlashLoan(address(debtToken)), type(uint256).max);
+
+        // expected fee for borrowing 1e18
+        uint256 borrowAmount = 1e18;
+        uint256 expectedFee  = borrowAmount * debtToken.FLASH_LOAN_FEE() / 10000;
+
+        // fee should be > 0
+        assertTrue(expectedFee > 0);
+
+        // fee should be exactly equal
+        assertEq(debtToken.flashFee(address(debtToken), borrowAmount), expectedFee);
+
+        // attempt to exploit rounding down to zero precision loss
+        // to get free flash loans by borrowing in small amounts - since
+        // DebtToken::flashLoan allows re-entrancy, the function could be re-entered
+        // multiple times to borrow larger amounts at zero fee
+        borrowAmount = 1111;
+        vm.expectRevert("ERC20FlashMint: amount too small");
+        debtToken.flashFee(address(debtToken), borrowAmount);
+
+    }
+}

--- a/test/foundry/dao/AdminVotingTest.t.sol
+++ b/test/foundry/dao/AdminVotingTest.t.sol
@@ -12,7 +12,9 @@ contract AdminVotingTest is TestSetup {
 
 
     uint256 constant internal INIT_MIN_CREATE_PROP_PCT = 10;   // 0.01%
+    uint256 constant internal UPDT_MIN_CREATE_PROP_PCT = 50;   // 0.05%
     uint256 constant internal INIT_PROP_PASSING_PCT    = 2000; // 20%
+    uint256 constant internal UPDT_PROP_PASSING_PCT    = 3000; // 30%
 
     function setUp() public virtual override {
         super.setUp();
@@ -90,13 +92,42 @@ contract AdminVotingTest is TestSetup {
         vm.stopPrank();
     }
 
-    function test_createNewProposal_setGuardian() external {
-        // create a setGuardian proposal that also contains a dummy proposal
-        AdminVoting.Action[] memory payload = new AdminVoting.Action[](2);
-        payload[0].target = address(0x0);
-        payload[0].data   = abi.encode("");
-        payload[1].target = address(babelCore);
-        payload[1].data   = abi.encodeWithSelector(IBabelCore.setGuardian.selector, users.user1);
+    // helper function to verify proposal data after creation
+    function _verifyCreatedProposal(uint256 proposalId, 
+                                    uint256 proposalWeek,
+                                    uint256 proposalPassingPct,
+                                    AdminVoting.Action[] memory payload) internal view {
+        // verify requiredWeight calculated using correct passing percent
+        assertEq(adminVoting.getProposalRequiredWeight(proposalId), 
+                 (tokenLocker.getTotalWeightAt(proposalWeek) * proposalPassingPct) /
+                 adminVoting.MAX_PCT());
+        // verify proposal details stored correctly
+        assertEq(adminVoting.getProposalWeek(proposalId), proposalWeek);
+        assertEq(adminVoting.getProposalCreatedAt(proposalId), block.timestamp);
+        assertEq(adminVoting.getProposalCurrentWeight(proposalId), 0);
+        assertEq(adminVoting.getProposalCanExecuteAfter(proposalId), 0);
+        assertEq(adminVoting.getProposalProcessed(proposalId), false);
+        assertEq(adminVoting.getProposalCanExecute(proposalId), false);
+
+        // verify payload correctly saved
+        AdminVoting.Action[] memory savedPayload = adminVoting.getProposalPayload(proposalId);
+        assertEq(payload.length, savedPayload.length);
+
+        for(uint256 i; i<payload.length; i++) {
+            assertEq(payload[i].target, savedPayload[i].target);
+            assertEq(payload[i].data, savedPayload[i].data);
+        }
+    }
+
+    function test_createNewProposal_setGuardian() public returns(uint256 proposalId) {
+        // create a setGuardian proposal that also contains other payloads
+        AdminVoting.Action[] memory payload = new AdminVoting.Action[](3);
+        payload[0].target = address(adminVoting);
+        payload[0].data   = abi.encodeWithSelector(AdminVoting.setMinCreateProposalPct.selector, UPDT_MIN_CREATE_PROP_PCT);
+        payload[1].target = address(adminVoting);
+        payload[1].data   = abi.encodeWithSelector(AdminVoting.setPassingPct.selector, UPDT_PROP_PASSING_PCT);
+        payload[2].target = address(babelCore);
+        payload[2].data   = abi.encodeWithSelector(IBabelCore.setGuardian.selector, users.user1);
 
         // lock up user tokens to receive voting power
         vm.prank(users.user1);
@@ -108,11 +139,252 @@ contract AdminVotingTest is TestSetup {
 
         // create the proposal
         vm.prank(users.user1);
+        proposalId = adminVoting.createNewProposal(users.user1, payload);
+
+        _verifyCreatedProposal(proposalId,
+                               adminVoting.getWeek()-1,
+                               adminVoting.SET_GUARDIAN_PASSING_PCT(),
+                               payload);
+    }
+
+    function test_createNewProposal_withVotingWeight() public returns(uint256 proposalId) {
+        // create proposal that updates 2 internal AdminVoting parameters
+        AdminVoting.Action[] memory payload = new AdminVoting.Action[](2);
+        payload[0].target = address(adminVoting);
+        payload[0].data   = abi.encodeWithSelector(AdminVoting.setMinCreateProposalPct.selector, UPDT_MIN_CREATE_PROP_PCT);
+        payload[1].target = address(adminVoting);
+        payload[1].data   = abi.encodeWithSelector(AdminVoting.setPassingPct.selector, UPDT_PROP_PASSING_PCT);
+
+        // lock up user tokens to receive voting power
+        vm.prank(users.user1);
+        tokenLocker.lock(users.user1, INIT_BAB_TKN_TOTAL_SUPPLY, 52);
+
+        // advance time by 1 week
+        vm.warp(block.timestamp + 1 weeks);
+        uint256 weekNum = 1;
+        assertEq(adminVoting.getWeek(), weekNum);
+
+        // create the proposal
+        vm.prank(users.user1);
+        proposalId = adminVoting.createNewProposal(users.user1, payload);
+
+        _verifyCreatedProposal(proposalId,
+                               weekNum-1,
+                               adminVoting.passingPct(),
+                               payload);
+    }
+
+    function test_createNewProposal_minTimeBetweenProposals() external {
+        // create first proposal
+        test_createNewProposal_withVotingWeight();
+
+        // verify attempting to quickly create another fails
+        AdminVoting.Action[] memory payload = new AdminVoting.Action[](1);
+        payload[0].target = address(0x0);
+        payload[0].data   = abi.encode("");
+
+        vm.expectRevert("MIN_TIME_BETWEEN_PROPOSALS");
+        vm.prank(users.user1);
         adminVoting.createNewProposal(users.user1, payload);
 
-        // verify requiredWeight is 50.1% majority for setGuardian proposals
-        assertEq(adminVoting.getProposalRequiredWeight(0), 
-                 (tokenLocker.getTotalWeight() * adminVoting.SET_GUARDIAN_PASSING_PCT()) /
+        // advance time by the minimum time between proposals
+        vm.warp(block.timestamp + adminVoting.MIN_TIME_BETWEEN_PROPOSALS() + 1);
+
+        // now user can create another proposal
+        vm.prank(users.user1);
+        adminVoting.createNewProposal(users.user1, payload);
+
+        // verify requiredWeight calculated using standard passing percent
+        assertEq(adminVoting.getProposalRequiredWeight(1), 
+                 (tokenLocker.getTotalWeightAt(adminVoting.getWeek()-1) * adminVoting.passingPct()) /
                  adminVoting.MAX_PCT());
+    }
+
+    // helper function to successfully cancel a proposal
+    function _cancelProposal(uint256 proposalId) internal {
+        // verify cancel works for guardian
+        vm.prank(users.guardian);
+        adminVoting.cancelProposal(proposalId);
+
+        // verify storage correctly updated
+        assertEq(adminVoting.getProposalProcessed(proposalId), true);
+
+        // verify proposal can't be executed
+        assertEq(adminVoting.getProposalCanExecute(proposalId), false);
+    }
+
+    function test_cancelProposal_onlyGuardianCanCancel() external {
+        // create first proposal
+        uint256 proposalId = test_createNewProposal_withVotingWeight();
+
+        // verify fails if non-guardian tries to cancel
+        vm.expectRevert("Only guardian can cancel proposals");
+        vm.prank(users.user1);
+        adminVoting.cancelProposal(proposalId);
+
+        _cancelProposal(proposalId);
+    }
+
+    function test_cancelProposal_cantCancelSetGuardian() external {
+        // create the setGuardian proposal
+        uint256 proposalId = test_createNewProposal_setGuardian();
+
+        // verify it is impossible to cancel
+        vm.expectRevert("Guardian replacement not cancellable");
+        vm.prank(users.guardian);
+        adminVoting.cancelProposal(proposalId);
+    }
+
+    function test_cancelProposal_cantCancelCancelledProposal() external {
+        // create the proposal
+        uint256 proposalId = test_createNewProposal_withVotingWeight();
+
+        // cancel it
+        _cancelProposal(proposalId);
+
+        // verify cancelling already cancelled proposal fails
+        vm.expectRevert("Already processed");
+        vm.prank(users.guardian);
+        adminVoting.cancelProposal(proposalId);
+    }
+
+    // helper function used to make a successful vote
+    function _voteForProposal(address voter, uint256 proposalId, uint256 votingWeight) internal {
+        uint256 previousWeight = adminVoting.getProposalCurrentWeight(proposalId);
+
+        // vote on it
+        vm.prank(voter);
+        adminVoting.voteForProposal(voter, proposalId, votingWeight);
+
+        // verify current voting weight correctly updated
+        assertEq(adminVoting.getProposalCurrentWeight(proposalId)-previousWeight, votingWeight);
+        // verify proposal still not processed
+        assertEq(adminVoting.getProposalProcessed(proposalId), false);
+        // verify proposal can't be executed
+        assertEq(adminVoting.getProposalCanExecute(proposalId), false);
+
+        // if voted with >= weight required to pass, verify the proposal passed
+        if(votingWeight >= adminVoting.getProposalRequiredWeight(proposalId)) {
+            assertEq(adminVoting.getProposalCanExecuteAfter(proposalId),
+                     block.timestamp + adminVoting.MIN_TIME_TO_EXECUTION());
+        }
+        // otherwise verify proposal has not passed
+        else {
+            assertEq(adminVoting.getProposalCanExecuteAfter(proposalId), 0);
+        }
+    }
+
+    function test_voteForProposal(uint256 votingWeight) external {
+        // create first proposal
+        uint256 proposalId = test_createNewProposal_withVotingWeight();
+
+        // bind fuzz inputs
+        votingWeight = bound(votingWeight,
+                              1,
+                              tokenLocker.getAccountWeightAt(users.user1,
+                                                             adminVoting.getProposalWeek(proposalId)));
+
+        _voteForProposal(users.user1, proposalId, votingWeight);
+    }
+
+    function test_voteForProposal_cantVoteWithMoreWeight(uint256 votingWeight) external {
+        // create first proposal
+        uint256 proposalId = test_createNewProposal_withVotingWeight();
+
+        // bind fuzz inputs
+        votingWeight = bound(votingWeight,
+                              tokenLocker.getAccountWeightAt(users.user1,
+                                                             adminVoting.getProposalWeek(proposalId)) + 1,
+                              type(uint256).max);
+
+        // verify voting with more weight than an account has fails
+        vm.expectRevert("Weight exceeds account weight");
+        vm.prank(users.user1);
+        adminVoting.voteForProposal(users.user1, proposalId, votingWeight);
+    }
+
+    function test_voteForProposal_sameUserCantVoteTwice() external {
+        // create first proposal
+        uint256 proposalId = test_createNewProposal_withVotingWeight();
+
+        uint256 halfVotingWeight
+            = tokenLocker.getAccountWeightAt(users.user1,
+                                             adminVoting.getProposalWeek(proposalId)) / 2;
+
+        // vote once works
+        _voteForProposal(users.user1, proposalId, halfVotingWeight);
+
+        // voting twice fails
+        vm.expectRevert("Already voted");
+        vm.prank(users.user1);
+        adminVoting.voteForProposal(users.user1, proposalId, halfVotingWeight);
+    }
+
+    // helper function to successfully execute a proposal
+    function _executeProposal(address voter, uint256 proposalId) internal {
+        // vote with full weight so proposal passes
+        _voteForProposal(voter,
+                         proposalId,
+                         tokenLocker.getAccountWeightAt(voter,
+                                                        adminVoting.getProposalWeek(proposalId)));
+
+        // warp to after proposal execution time
+        vm.warp(adminVoting.getProposalCanExecuteAfter(proposalId) + 1);
+
+        // verify proposal can be executed
+        assertEq(adminVoting.getProposalCanExecute(proposalId), true);
+
+        // execute the proposal
+        adminVoting.executeProposal(proposalId);
+
+        // verify the min create proposal percentage was updated
+        assertEq(adminVoting.minCreateProposalPct(), UPDT_MIN_CREATE_PROP_PCT);
+
+        // verify the pass percentage was updated
+        assertEq(adminVoting.passingPct(), UPDT_PROP_PASSING_PCT);
+    }
+
+    function test_executeProposal_setGuardian() public returns(uint256 proposalId) {
+        // transfer ownership of BabelCore to the DAO
+        vm.prank(users.owner);
+        babelCore.commitTransferOwnership(address(adminVoting));
+        vm.warp(block.timestamp + babelCore.OWNERSHIP_TRANSFER_DELAY() + 1);
+        adminVoting.acceptTransferOwnership();
+        assertEq(babelCore.owner(), address(adminVoting));
+
+        // create the `setGuardian` proposal which also calls
+        // `setPassingPct` and `setMinCreateProposalPct`
+        proposalId = test_createNewProposal_setGuardian();
+
+        _executeProposal(users.user1, proposalId);
+
+        // verify the guardian was updated
+        assertEq(babelCore.guardian(), address(users.user1));
+    }
+
+    function test_executeProposal_cantExecuteTwice() external {
+        // execute once
+        uint256 executedProposalId = test_executeProposal_setGuardian();
+
+        // verify second execution of same proposal fails
+        vm.expectRevert("Already processed");
+        adminVoting.executeProposal(executedProposalId);
+    }
+
+    function test_executeProposal_withoutSetGuardian() public returns(uint256 proposalId) {
+        // create the proposal
+        proposalId = test_createNewProposal_withVotingWeight();
+
+        _executeProposal(users.user1, proposalId);
+    }
+
+    function test_executeProposal_cantCancelExecutedProposal() external {
+        // execute once
+        uint256 executedProposalId = test_executeProposal_withoutSetGuardian();
+
+        // verify cancelling already executed proposal fails
+        vm.expectRevert("Already processed");
+        vm.prank(users.guardian);
+        adminVoting.cancelProposal(executedProposalId);
     }
 }

--- a/test/foundry/dao/AdminVotingTest.t.sol
+++ b/test/foundry/dao/AdminVotingTest.t.sol
@@ -321,11 +321,14 @@ contract AdminVotingTest is TestSetup {
         // create first proposal
         uint256 proposalId = test_createNewProposal_withVotingWeight();
 
+        // save voting weights
+        uint256 user1Weight = tokenLocker.getAccountWeightAt(users.user1,
+                                                             adminVoting.getProposalWeek(proposalId));
+        uint256 user2Weight = tokenLocker.getAccountWeightAt(users.user2,
+                                                             adminVoting.getProposalWeek(proposalId));
+
         // first user votes with enough weight to pass proposal
-        _voteForProposal(users.user1,
-                         proposalId,
-                         tokenLocker.getAccountWeightAt(users.user1,
-                                                        adminVoting.getProposalWeek(proposalId)));
+        _voteForProposal(users.user1, proposalId, user1Weight);
                                                     
         // verify proposal has passed
         assertEq(adminVoting.getProposalPassed(proposalId), true);
@@ -334,10 +337,10 @@ contract AdminVotingTest is TestSetup {
         assertEq(adminVoting.getProposalProcessed(proposalId), false);
 
         // user2 can still vote on the proposal, even though it has passed
-        _voteForProposal(users.user2,
-                         proposalId,
-                         tokenLocker.getAccountWeightAt(users.user2,
-                                                        adminVoting.getProposalWeek(proposalId)));
+        _voteForProposal(users.user2, proposalId, user2Weight);
+
+        // verify proposal's voting weight has accumulated from both votes
+        assertEq(adminVoting.getProposalCurrentWeight(proposalId), user1Weight + user2Weight);
     }
 
     function test_voteForProposal_cantVoteWithMoreWeight(uint256 votingWeight) external {

--- a/test/foundry/dao/AdminVotingTest.t.sol
+++ b/test/foundry/dao/AdminVotingTest.t.sol
@@ -10,7 +10,6 @@ import {TestSetup, IBabelVault} from "../TestSetup.sol";
 contract AdminVotingTest is TestSetup {
     AdminVoting adminVoting;
 
-
     uint256 constant internal INIT_MIN_CREATE_PROP_PCT = 10;   // 0.01%
     uint256 constant internal UPDT_MIN_CREATE_PROP_PCT = 50;   // 0.05%
     uint256 constant internal INIT_PROP_PASSING_PCT    = 2000; // 20%
@@ -138,8 +137,10 @@ contract AdminVotingTest is TestSetup {
         payload[2].data   = abi.encodeWithSelector(IBabelCore.setGuardian.selector, users.user1);
 
         // lock up user tokens to receive voting power
+        // need to divide by lockToTokenRatio when calling the
+        // lock function since the token transfer multiplies by lockToTokenRatio
         vm.prank(users.user1);
-        tokenLocker.lock(users.user1, USER1_TOKEN_ALLOCATION, 52);
+        tokenLocker.lock(users.user1, USER1_TOKEN_ALLOCATION/INIT_LOCK_TO_TOKEN_RATIO, 52);
 
         // warp forward BOOTSTRAP_PERIOD so voting power becomes active
         // and setGuardian proposals are allowed
@@ -164,8 +165,10 @@ contract AdminVotingTest is TestSetup {
         payload[1].data   = abi.encodeWithSelector(AdminVoting.setPassingPct.selector, UPDT_PROP_PASSING_PCT);
 
         // lock up user tokens to receive voting power
+        // need to divide by lockToTokenRatio when calling the
+        // lock function since the token transfer multiplies by lockToTokenRatio
         vm.prank(users.user1);
-        tokenLocker.lock(users.user1, USER1_TOKEN_ALLOCATION, 52);
+        tokenLocker.lock(users.user1, USER1_TOKEN_ALLOCATION/INIT_LOCK_TO_TOKEN_RATIO, 52);
 
         // advance time by 1 week
         vm.warp(block.timestamp + 1 weeks);
@@ -298,8 +301,10 @@ contract AdminVotingTest is TestSetup {
 
     function test_voteForProposal_differentVotersAccumulate() external {
         // lock up user2 tokens to receive voting power
+        // need to divide by lockToTokenRatio when calling the
+        // lock function since the token transfer multiplies by lockToTokenRatio
         vm.prank(users.user2);
-        tokenLocker.lock(users.user2, USER2_TOKEN_ALLOCATION, 52);
+        tokenLocker.lock(users.user2, USER2_TOKEN_ALLOCATION/INIT_LOCK_TO_TOKEN_RATIO, 52);
 
         // create first proposal
         uint256 proposalId = test_createNewProposal_withVotingWeight();
@@ -316,8 +321,10 @@ contract AdminVotingTest is TestSetup {
 
     function test_voteForProposal_canVoteOnPassedProposal() external {
         // lock up user2 tokens to receive voting power
+        // need to divide by lockToTokenRatio when calling the
+        // lock function since the token transfer multiplies by lockToTokenRatio
         vm.prank(users.user2);
-        tokenLocker.lock(users.user2, USER2_TOKEN_ALLOCATION, 52);
+        tokenLocker.lock(users.user2, USER2_TOKEN_ALLOCATION/INIT_LOCK_TO_TOKEN_RATIO, 52);
 
         // create first proposal
         uint256 proposalId = test_createNewProposal_withVotingWeight();

--- a/test/foundry/dao/AdminVotingTest.t.sol
+++ b/test/foundry/dao/AdminVotingTest.t.sol
@@ -321,9 +321,6 @@ contract AdminVotingTest is TestSetup {
         // create first proposal
         uint256 proposalId = test_createNewProposal_withVotingWeight();
 
-        // each user votes with 50 weight
-        uint256 votingWeight = 50;
-
         // first user votes with enough weight to pass proposal
         _voteForProposal(users.user1,
                          proposalId,
@@ -337,7 +334,10 @@ contract AdminVotingTest is TestSetup {
         assertEq(adminVoting.getProposalProcessed(proposalId), false);
 
         // user2 can still vote on the proposal, even though it has passed
-        _voteForProposal(users.user2, proposalId, votingWeight);
+        _voteForProposal(users.user2,
+                         proposalId,
+                         tokenLocker.getAccountWeightAt(users.user2,
+                                                        adminVoting.getProposalWeek(proposalId)));
     }
 
     function test_voteForProposal_cantVoteWithMoreWeight(uint256 votingWeight) external {

--- a/test/foundry/dao/AdminVotingTest.t.sol
+++ b/test/foundry/dao/AdminVotingTest.t.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {AdminVoting} from "../../../contracts/dao/AdminVoting.sol";
+
+// test setup
+import {TestSetup} from "../TestSetup.sol";
+
+contract AdminVotingTest is TestSetup {
+    AdminVoting adminVoting;
+
+
+    uint256 constant internal INIT_MIN_CREATE_PROP_PCT = 10;   // 0.01%
+    uint256 constant internal INIT_PROP_PASSING_PCT    = 2000; // 20%
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        adminVoting = new AdminVoting(address(babelCore),
+                                      tokenLocker,
+                                      INIT_MIN_CREATE_PROP_PCT,
+                                      INIT_PROP_PASSING_PCT);
+    }
+
+    function test_constructor() external view {
+        // parameters correctly set
+        assertEq(adminVoting.minCreateProposalPct(), INIT_MIN_CREATE_PROP_PCT);
+        assertEq(adminVoting.passingPct(), INIT_PROP_PASSING_PCT);
+        assertEq(address(adminVoting.tokenLocker()), address(tokenLocker));
+
+        // week initialized to zero
+        assertEq(adminVoting.getWeek(), 0);
+        assertEq(adminVoting.minCreateProposalWeight(), 0);
+
+        // no proposals
+        assertEq(adminVoting.getProposalCount(), 0);
+    }
+
+    function test_createNewProposal_inInitialState() external {
+        // create dummy proposal
+        AdminVoting.Action[] memory payload = new AdminVoting.Action[](1);
+        payload[0].target = address(0x0);
+        payload[0].data   = abi.encode("");
+
+        uint256 lastProposalTimestamp = adminVoting.latestProposalTimestamp(users.user1);
+        assertEq(lastProposalTimestamp, 0);
+
+        // verify no proposals can be created in first week
+        vm.startPrank(users.user1);
+        vm.expectRevert("No proposals in first week");
+        adminVoting.createNewProposal(users.user1, payload);
+
+        // advance time by 1 week
+        vm.warp(block.timestamp + 1 weeks);
+        uint256 weekNum = 1;
+        assertEq(adminVoting.getWeek(), weekNum);
+
+        // verify there are no tokens locked
+        assertEq(tokenLocker.getTotalWeightAt(weekNum), 0);
+
+        // verify no proposals can be created if there is no
+        // total voting weight in that week
+        vm.expectRevert("Zero total voting weight for given week");
+        adminVoting.createNewProposal(users.user1, payload);
+        vm.stopPrank();
+    }
+}

--- a/test/foundry/dao/TokenLockerTest.t.sol
+++ b/test/foundry/dao/TokenLockerTest.t.sol
@@ -32,9 +32,6 @@ contract TokenLockerTest is TestSetup {
 
         // verify recipients have received voting tokens
         assertEq(babelToken.balanceOf(users.user1), INIT_BAB_TKN_TOTAL_SUPPLY);
-
-        // verify we are in the first week
-        assertEq(tokenLocker.getWeek(), 0);
     }
 
     function test_lock(uint256 amountToLock, uint256 weeksToLockFor) public

--- a/test/foundry/dao/TokenLockerTest.t.sol
+++ b/test/foundry/dao/TokenLockerTest.t.sol
@@ -37,27 +37,29 @@ contract TokenLockerTest is TestSetup {
         assertEq(tokenLocker.getWeek(), 0);
     }
 
-    function test_lock(uint256 amountToLock, uint256 weeksToLockFor) public {
+    function test_lock(uint256 amountToLock, uint256 weeksToLockFor) public
+        returns(uint256 lockedAmount, uint256 weeksLockedFor) 
+    {
         // save user initial balance
         uint256 userInitialBalance = babelToken.balanceOf(users.user1);
         assertEq(userInitialBalance, INIT_BAB_TKN_TOTAL_SUPPLY);
 
         // bound fuzz inputs
-        amountToLock = bound(amountToLock, 1, userInitialBalance);
-        weeksToLockFor = bound(weeksToLockFor, 1, tokenLocker.MAX_LOCK_WEEKS());
+        lockedAmount = bound(amountToLock, 1, userInitialBalance);
+        weeksLockedFor = bound(weeksToLockFor, 1, tokenLocker.MAX_LOCK_WEEKS());
 
         // verify user has no voting weight
         assertEq(tokenLocker.getAccountWeight(users.user1), 0);
 
         // lock up random amount for random weeks
         vm.prank(users.user1);
-        tokenLocker.lock(users.user1, amountToLock, weeksToLockFor);
+        tokenLocker.lock(users.user1, lockedAmount, weeksLockedFor);
 
         // verify locked amount is correct
         (uint256 locked, uint256 unlocked) = tokenLocker.getAccountBalances(users.user1);
-        assertEq(locked, amountToLock);
+        assertEq(locked, lockedAmount);
         assertEq(unlocked, 0);
-        assertEq(babelToken.balanceOf(users.user1), userInitialBalance - amountToLock);
+        assertEq(babelToken.balanceOf(users.user1), userInitialBalance - lockedAmount);
 
         // verify user has positive voting weight in the current week
         uint256 userWeight = tokenLocker.getAccountWeight(users.user1);
@@ -73,17 +75,17 @@ contract TokenLockerTest is TestSetup {
         assertEq(tokenLocker.getTotalWeightAt(tokenLocker.getWeek()+1), 0);
 
         // verify user active locks are correct
-        (ITokenLocker.LockData[] memory activeLockData, uint256 frozenAmount)   
+        (ITokenLocker.LockData[] memory activeLockData, uint256 frozenAmount)
             = tokenLocker.getAccountActiveLocks(users.user1, 0);
 
         assertEq(activeLockData.length, 1);
         assertEq(frozenAmount, 0);
-        assertEq(activeLockData[0].amount, amountToLock);
+        assertEq(activeLockData[0].amount, lockedAmount);
 
         // this behavior is weird and not sure if it is correct;
         // if user locks for   1 week, activeLockData[0].weeksToUnlock == weeksToLockFor + 1 == 2
         // if user locks for > 1 week, activeLockData[0].weeksToUnlock == weeksToLockFor
-        assertEq(activeLockData[0].weeksToUnlock, weeksToLockFor == 1 ? 2 : weeksToLockFor);
+        assertEq(activeLockData[0].weeksToUnlock, weeksLockedFor == 1 ? 2 : weeksLockedFor);
     }
 
     function test_lock_immediate_withdraw(uint256 amountToLock, uint256 weeksToLockFor, uint256 relockFor) external {
@@ -97,5 +99,87 @@ contract TokenLockerTest is TestSetup {
         vm.expectRevert("No unlocked tokens");
         vm.prank(users.user1);
         tokenLocker.withdrawExpiredLocks(relockFor);
+    }
+
+    function test_lock_warp_withdraw(uint256 amountToLock, uint256 weeksToLockFor, uint256 relockFor) external {
+        // bound fuzz input
+        relockFor = bound(relockFor, 0, tokenLocker.MAX_LOCK_WEEKS());
+
+        // perform the lock
+        (uint256 lockedAmount, uint256 weeksLockedFor) = test_lock(amountToLock, weeksToLockFor);
+
+        // see note about weird behavior at the end of test_lock
+        uint256 weeksToWarp = weeksLockedFor == 1 ? 2 : weeksLockedFor;
+
+        // warp time forward so the lock elapses
+        vm.warp(block.timestamp + 1 weeks * weeksToWarp);
+
+        // perform the unlock
+        vm.prank(users.user1);
+        tokenLocker.withdrawExpiredLocks(relockFor);
+
+        // if no relocking, verify user received their tokens
+        if(relockFor == 0) {
+            assertEq(babelToken.balanceOf(users.user1), INIT_BAB_TKN_TOTAL_SUPPLY);
+
+            // verify no locked amount
+            (uint256 locked, uint256 unlocked) = tokenLocker.getAccountBalances(users.user1);
+            assertEq(locked, 0);
+            assertEq(unlocked, 0);
+
+            // verify user has no voting weight in the current week
+            uint256 userWeight = tokenLocker.getAccountWeight(users.user1);
+            assertEq(userWeight, 0);
+
+            // verify user has no voting weight for future weeks
+            assertEq(tokenLocker.getAccountWeightAt(users.user1, tokenLocker.getWeek()+1), 0);
+
+            // verify no total weight for current week
+            assertEq(tokenLocker.getTotalWeight(), 0);
+
+            // verify no total weight for future weeks
+            assertEq(tokenLocker.getTotalWeightAt(tokenLocker.getWeek()+1), 0);
+
+            // verify no user active locks
+            (ITokenLocker.LockData[] memory activeLockData, uint256 frozenAmount)
+                = tokenLocker.getAccountActiveLocks(users.user1, 0);
+
+            assertEq(activeLockData.length, 0);
+            assertEq(frozenAmount, 0);
+        }
+        // otherwise verify that relocking has occured correctly
+        else{
+            // verify locked amount is correct
+            (uint256 locked, uint256 unlocked) = tokenLocker.getAccountBalances(users.user1);
+            assertEq(locked, lockedAmount);
+            assertEq(unlocked, 0);
+            assertEq(babelToken.balanceOf(users.user1), INIT_BAB_TKN_TOTAL_SUPPLY - lockedAmount);
+
+            // verify user has positive voting weight in the current week
+            uint256 userWeight = tokenLocker.getAccountWeight(users.user1);
+            assertTrue(userWeight > 0);
+
+            // verify user has no voting weight for future weeks
+            assertEq(tokenLocker.getAccountWeightAt(users.user1, tokenLocker.getWeek()+1), 0);
+
+            // verify total weight for current week all belongs to user
+            assertEq(tokenLocker.getTotalWeight(), userWeight);
+
+            // verify no total weight for future weeks
+            assertEq(tokenLocker.getTotalWeightAt(tokenLocker.getWeek()+1), 0);
+
+            // verify user active locks are correct
+            (ITokenLocker.LockData[] memory activeLockData, uint256 frozenAmount)
+                = tokenLocker.getAccountActiveLocks(users.user1, 0);
+
+            assertEq(activeLockData.length, 1);
+            assertEq(frozenAmount, 0);
+            assertEq(activeLockData[0].amount, lockedAmount);
+
+            // this behavior is weird and not sure if it is correct;
+            // if user locks for   1 week, activeLockData[0].weeksToUnlock == weeksToLockFor + 1 == 2
+            // if user locks for > 1 week, activeLockData[0].weeksToUnlock == weeksToLockFor
+            assertEq(activeLockData[0].weeksToUnlock, relockFor == 1 ? 2 : relockFor);
+        }
     }
 }

--- a/test/foundry/dao/TokenLockerTest.t.sol
+++ b/test/foundry/dao/TokenLockerTest.t.sol
@@ -42,7 +42,9 @@ contract TokenLockerTest is TestSetup {
         assertEq(userInitialBalance, INIT_BAB_TKN_TOTAL_SUPPLY);
 
         // bound fuzz inputs
-        lockedAmount = bound(amountToLock, 1, userInitialBalance);
+        // need to divide by lockToTokenRatio when calling the
+        // lock function since the token transfer multiplies by lockToTokenRatio
+        lockedAmount = bound(amountToLock, 1, userInitialBalance/INIT_LOCK_TO_TOKEN_RATIO);
         weeksLockedFor = bound(weeksToLockFor, 1, tokenLocker.MAX_LOCK_WEEKS());
 
         // verify user has no voting weight
@@ -56,7 +58,9 @@ contract TokenLockerTest is TestSetup {
         (uint256 locked, uint256 unlocked) = tokenLocker.getAccountBalances(users.user1);
         assertEq(locked, lockedAmount);
         assertEq(unlocked, 0);
-        assertEq(babelToken.balanceOf(users.user1), userInitialBalance - lockedAmount);
+        // when checking actual token balances, need to multipy lockedAmount by
+        // lockToTokenRatio since the token transfer multiplies by lockToTokenRatio
+        assertEq(babelToken.balanceOf(users.user1), userInitialBalance - lockedAmount*INIT_LOCK_TO_TOKEN_RATIO);
 
         // verify user has positive voting weight in the current week
         uint256 userWeight = tokenLocker.getAccountWeight(users.user1);
@@ -150,7 +154,10 @@ contract TokenLockerTest is TestSetup {
             (uint256 locked, uint256 unlocked) = tokenLocker.getAccountBalances(users.user1);
             assertEq(locked, lockedAmount);
             assertEq(unlocked, 0);
-            assertEq(babelToken.balanceOf(users.user1), INIT_BAB_TKN_TOTAL_SUPPLY - lockedAmount);
+            // when checking actual token balances, need to multipy lockedAmount by
+            // lockToTokenRatio since the token transfer multiplies by lockToTokenRatio
+            assertEq(babelToken.balanceOf(users.user1), 
+                     INIT_BAB_TKN_TOTAL_SUPPLY - lockedAmount*INIT_LOCK_TO_TOKEN_RATIO);
 
             // verify user has positive voting weight in the current week
             uint256 userWeight = tokenLocker.getAccountWeight(users.user1);

--- a/test/foundry/dao/TokenLockerTest.t.sol
+++ b/test/foundry/dao/TokenLockerTest.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup, IBabelVault, ITokenLocker} from "../TestSetup.sol";
+
+contract TokenLockerTest is TestSetup {
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // setup the vault to get BabelTokens which are used for voting
+        uint128[] memory _fixedInitialAmounts;
+        IBabelVault.InitialAllowance[] memory initialAllowances 
+            = new IBabelVault.InitialAllowance[](1);
+        
+        // give user1 allowance over the entire supply of voting tokens
+        initialAllowances[0].receiver = users.user1;
+        initialAllowances[0].amount = INIT_BAB_TKN_TOTAL_SUPPLY;
+
+        vm.prank(users.owner);
+        babelVault.setInitialParameters(emissionSchedule,
+                                        boostCalc,
+                                        INIT_BAB_TKN_TOTAL_SUPPLY,
+                                        INIT_VLT_LOCK_WEEKS,
+                                        _fixedInitialAmounts,
+                                        initialAllowances);
+
+        // transfer voting tokens to recipients
+        vm.prank(users.user1);
+        babelToken.transferFrom(address(babelVault), users.user1, INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // verify recipients have received voting tokens
+        assertEq(babelToken.balanceOf(users.user1), INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // verify we are in the first week
+        assertEq(tokenLocker.getWeek(), 0);
+    }
+
+    function test_lock(uint256 amountToLock, uint256 weeksToLockFor) public {
+        // save user initial balance
+        uint256 userInitialBalance = babelToken.balanceOf(users.user1);
+        assertEq(userInitialBalance, INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // bound fuzz inputs
+        amountToLock = bound(amountToLock, 1, userInitialBalance);
+        weeksToLockFor = bound(weeksToLockFor, 1, tokenLocker.MAX_LOCK_WEEKS());
+
+        // verify user has no voting weight
+        assertEq(tokenLocker.getAccountWeight(users.user1), 0);
+
+        // lock up random amount for random weeks
+        vm.prank(users.user1);
+        tokenLocker.lock(users.user1, amountToLock, weeksToLockFor);
+
+        // verify locked amount is correct
+        (uint256 locked, uint256 unlocked) = tokenLocker.getAccountBalances(users.user1);
+        assertEq(locked, amountToLock);
+        assertEq(unlocked, 0);
+        assertEq(babelToken.balanceOf(users.user1), userInitialBalance - amountToLock);
+
+        // verify user has positive voting weight in the current week
+        uint256 userWeight = tokenLocker.getAccountWeight(users.user1);
+        assertTrue(userWeight > 0);
+
+        // verify user has no voting weight for future weeks
+        assertEq(tokenLocker.getAccountWeightAt(users.user1, tokenLocker.getWeek()+1), 0);
+
+        // verify total weight for current week all belongs to user
+        assertEq(tokenLocker.getTotalWeight(), userWeight);
+
+        // verify no total weight for future weeks
+        assertEq(tokenLocker.getTotalWeightAt(tokenLocker.getWeek()+1), 0);
+
+        // verify user active locks are correct
+        (ITokenLocker.LockData[] memory activeLockData, uint256 frozenAmount)   
+            = tokenLocker.getAccountActiveLocks(users.user1, 0);
+
+        assertEq(activeLockData.length, 1);
+        assertEq(frozenAmount, 0);
+        assertEq(activeLockData[0].amount, amountToLock);
+
+        // this behavior is weird and not sure if it is correct;
+        // if user locks for   1 week, activeLockData[0].weeksToUnlock == weeksToLockFor + 1 == 2
+        // if user locks for > 1 week, activeLockData[0].weeksToUnlock == weeksToLockFor
+        assertEq(activeLockData[0].weeksToUnlock, weeksToLockFor == 1 ? 2 : weeksToLockFor);
+    }
+
+    function test_lock_immediate_withdraw(uint256 amountToLock, uint256 weeksToLockFor, uint256 relockFor) external {
+        // bound fuzz input
+        relockFor = bound(relockFor, 0, tokenLocker.MAX_LOCK_WEEKS());
+
+        // perform the lock
+        test_lock(amountToLock, weeksToLockFor);
+
+        // verify immediate withdraw reverts with correct error
+        vm.expectRevert("No unlocked tokens");
+        vm.prank(users.user1);
+        tokenLocker.withdrawExpiredLocks(relockFor);
+    }
+}

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -1,47 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-// vault specific members
-import {IEmissionSchedule} from "../../../contracts/interfaces/IEmissionSchedule.sol";
-import {IBoostCalculator} from "../../../contracts/interfaces/IBoostCalculator.sol";
-import {EmissionSchedule} from "../../../contracts/dao/EmissionSchedule.sol";
-import {BoostCalculator} from "../../../contracts/dao/BoostCalculator.sol";
-
 // test setup
 import {TestSetup, IBabelVault, BabelVault, IIncentiveVoting, ITokenLocker} from "../TestSetup.sol";
 
 contract VaultTest is TestSetup {
-    // only vault uses these
-    EmissionSchedule internal emissionSchedule;
-    BoostCalculator  internal boostCalc;
-
-    uint256 internal constant INIT_BS_GRACE_WEEKS = 1;
-    uint64 internal constant INIT_ES_LOCK_WEEKS = 4;
-    uint64 internal constant INIT_ES_LOCK_DECAY_WEEKS = 1;
-    uint64 internal constant INIT_ES_WEEKLY_PCT = 2500; // 25%
-    uint64[2][] internal scheduledWeeklyPct;
-
-    uint256 internal constant INIT_BAB_TKN_TOTAL_SUPPLY = 1_000_000e18;
-    uint64 internal constant INIT_VLT_LOCK_WEEKS = 2;
-
-    function setUp() public virtual override {
-        super.setUp();
-        
-        // create EmissionSchedule
-        emissionSchedule = new EmissionSchedule(address(babelCore), 
-                                                IIncentiveVoting(address(incentiveVoting)),
-                                                IBabelVault(address(babelVault)),
-                                                INIT_ES_LOCK_WEEKS,
-                                                INIT_ES_LOCK_DECAY_WEEKS,
-                                                INIT_ES_WEEKLY_PCT,
-                                                scheduledWeeklyPct);
-
-        // create BoostCalculator
-        boostCalc = new BoostCalculator(address(babelCore),
-                                        ITokenLocker(address(tokenLocker)),
-                                        INIT_BS_GRACE_WEEKS);
-    }
-
+    
     function test_constructor() external view {
         // addresses correctly set
         assertEq(address(babelVault.babelToken()), address(babelToken));
@@ -61,7 +25,7 @@ contract VaultTest is TestSetup {
 
     function test_setInitialParameters() public {
         uint128[] memory _fixedInitialAmounts;
-        BabelVault.InitialAllowance[] memory initialAllowances;
+        IBabelVault.InitialAllowance[] memory initialAllowances;
 
         vm.prank(users.owner);
         babelVault.setInitialParameters(emissionSchedule,


### PR DESCRIPTION
**Finding L-2:**
`DebtToken::flashLoan` fees can be bypassed by borrowing in small amounts

**Description:**
`DebtToken::flashLoan` fees can be bypassed by borrowing in small amounts to trigger [rounding down to zero](https://dacian.me/precision-loss-errors#heading-rounding-down-to-zero) precision loss in fee calculation. Since this function allows re-entrancy, the function can be re-entered multiple times to borrow larger amounts with zero fee.

**Impact:**
Flash loan fees can be bypassed.

**Proof of Concept:**
Add following test contract to `test/foundry/core/DebtTokenTest.t.sol`:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.19;

// test setup
import {TestSetup, DebtToken} from "../TestSetup.sol";

contract DebtTokenTest is TestSetup {

    function test_flashLoan() external {
        // entire supply initially available to borrow
        assertEq(debtToken.maxFlashLoan(address(debtToken)), type(uint256).max);

        // expected fee for borrowing 1e18
        uint256 borrowAmount = 1e18;
        uint256 expectedFee  = borrowAmount * debtToken.FLASH_LOAN_FEE() / 10000;

        // fee should be > 0
        assertTrue(expectedFee > 0);

        // fee should exactly equal
        assertEq(debtToken.flashFee(address(debtToken), borrowAmount), expectedFee);

        // exploit rounding down to zero precision loss to get free flash loans
        // by borrowing in small amounts
        borrowAmount = 1111;
        assertEq(debtToken.flashFee(address(debtToken), borrowAmount), 0);

        // as DebtToken::flashLoan allows re-entrancy, the function can be re-entered
        // multiple times to borrow larger amounts at zero fee
    }
}
```

Run with: `forge test --match-test test_flashLoan`

**Recommended Mitigation:**
`DebtToken::_flashFee` should revert if calculated fee is zero:
```solidity
function _flashFee(uint256 amount) internal pure returns (uint256 fee) {
    fee = (amount * FLASH_LOAN_FEE) / 10000;
    require(fee > 0, "ERC20FlashMint: amount too small");
}
```

--------------------------------

**Finding L-3:**
Using `ecrecover` directly vulnerable to signature malleability

**Description:**
`DebtToken::permit` and `BabelToken::permit` call `ecrecover` directly but due to the symmetrical nature of the elliptic curve for every `[v,r,s]` there exists another `[v,r,s]` that returns the same valid result. 

**Impact:**
Usage of `ecrecover` directly is vulnerable to [signature malleability](https://dacian.me/signature-replay-attacks#heading-signature-malleability).

**Recommended Mitigation:**
Use OpenZeppelin's [ECDSA](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol) library with a version of OpenZeppelin >= 4.7.3. 

--------------------------------

**Finding L-4:**
Proposal creation bypasses minimum voting weight requirement when no tokens are locked hence no voting power exists

**Description:**
`AdminVoting::minCreateProposalPct` specifies the minimum voting weight required to create proposals, however this is bypassed allowing anyone to create proposals when no tokens are locked and hence no voting power exists.

**Proof of Concept:**
Firstly change `test/foundry/TestSetup.sol` to warp time forward in `setUp`:
```solidity
function setUp() public virtual {
    // prevent Foundry from setting block.timestamp = 1 which can cause
    // errors in this protocol
    vm.warp(1659973223);
```

Then add the following test contract to `/test/foundry/dao/AdminVotingTest.t.sol`:
```solidity
// SPDX-License-Identifier: MIT
pragma solidity 0.8.19;

import {AdminVoting} from "../../../contracts/dao/AdminVoting.sol";

// test setup
import {TestSetup} from "../TestSetup.sol";

contract AdminVotingTest is TestSetup {
    AdminVoting adminVoting;

    uint256 constant internal INIT_MIN_CREATE_PROP_PCT = 10;   // 0.01%
    uint256 constant internal INIT_PROP_PASSING_PCT    = 2000; // 20%

    function setUp() public virtual override {
        super.setUp();

        adminVoting = new AdminVoting(address(babelCore),
                                      tokenLocker,
                                      INIT_MIN_CREATE_PROP_PCT,
                                      INIT_PROP_PASSING_PCT);
    }

    function test_constructor() external view {
        // parameters correctly set
        assertEq(adminVoting.minCreateProposalPct(), INIT_MIN_CREATE_PROP_PCT);
        assertEq(adminVoting.passingPct(), INIT_PROP_PASSING_PCT);
        assertEq(address(adminVoting.tokenLocker()), address(tokenLocker));

        // week initialized to zero
        assertEq(adminVoting.getWeek(), 0);
        assertEq(adminVoting.minCreateProposalWeight(), 0);

        // no proposals
        assertEq(adminVoting.getProposalCount(), 0);
    }

    function test_createNewProposal_inInitialState() external {
        // create dummy proposal
        AdminVoting.Action[] memory payload = new AdminVoting.Action[](1);
        payload[0].target = address(0x0);
        payload[0].data   = abi.encode("");

        uint256 lastProposalTimestamp = adminVoting.latestProposalTimestamp(users.user1);
        assertEq(lastProposalTimestamp, 0);

        // verify expected failure condition
        vm.startPrank(users.user1);
        vm.expectRevert("No proposals in first week");
        adminVoting.createNewProposal(users.user1, payload);

        // advance time by 1 week
        vm.warp(block.timestamp + 1 weeks);
        uint256 weekNum = 1;
        assertEq(adminVoting.getWeek(), weekNum);

        // verify there are no tokens locked
        assertEq(tokenLocker.getTotalWeightAt(weekNum), 0);

        // even though there are no tokens locked so users have no voting weight,
        // a user with no voting weight can still create a proposal!
        adminVoting.createNewProposal(users.user1, payload);
        vm.stopPrank();

        // verify proposal has been created
        assertEq(adminVoting.getProposalCount(), 1);

        // attempting to execute the proposal fails with correct error
        uint256 proposalId = 0;
        vm.expectRevert("Not passed");
        adminVoting.executeProposal(proposalId);

        // attempting to vote on the proposal fails with correct error
        vm.expectRevert("No vote weight");
        vm.prank(users.user1);
        adminVoting.voteForProposal(users.user1, proposalId, 0);

        // so this can't be exploited further
    }
}
```

Run with: `forge test --match-contract AdminVotingTest`.

**Recommended Mitigation:**
Prevent proposal creation when there is no total voting weight for that week by changing `AdminVoting::minCreateProposalWeight` to revert in this case:
```diff
    function minCreateProposalWeight() public view returns (uint256) {
        uint256 week = getWeek();
        if (week == 0) return 0;
        week -= 1;

        uint256 totalWeight = tokenLocker.getTotalWeightAt(week);
+       require(totalWeight > 0, "Zero total voting weight for given week");

        return (totalWeight * minCreateProposalPct) / MAX_PCT;
    }
```

--------------------------------

**Finding L-5:**

**Description:**
`AdminVoting::createNewProposal` calls `_isSetGuardianPayload` to detect whether a proposal contains a call to `IBabelCore.setGuardian`. If `true` then it requires a 50.1% majority in order for the `setGuardian` proposal to succeed, otherwise it uses the configured proposal pass percentage which is expected to be lower.

However this only works if there is only 1 payload and that payload calls `IBabelCore.setGuardian`. A malicious actor can easily bypass this by creating a proposal with 2 payloads where the second payload just does nothing.

**Impact:**
A malicious actor can easily create a malicious `setGuardian` proposal that can be passed with the lower pass percentage, bypassing the requirement for a 50.1% majority on `setGuardian` proposals.

**Proof of Concept:**
Add the PoC function to `test/foundry/dao/AdminVotingTest.t.sol`:
```solidity
function test_createNewProposal_setGuardian() external {
    // create a setGuardian proposal that also contains a dummy proposal
    AdminVoting.Action[] memory payload = new AdminVoting.Action[](2);
    payload[0].target = address(0x0);
    payload[0].data   = abi.encode("");
    payload[1].target = address(babelCore);
    payload[1].data   = abi.encodeWithSelector(IBabelCore.setGuardian.selector, users.user1);

    // lock up user tokens to receive voting power
    vm.prank(users.user1);
    tokenLocker.lock(users.user1, INIT_BAB_TKN_TOTAL_SUPPLY, 52);

    // warp forward BOOTSTRAP_PERIOD so voting power becomes active
    // and setGuardian proposals are allowed
    vm.warp(block.timestamp + adminVoting.BOOTSTRAP_PERIOD());

    // create the proposal
    vm.prank(users.user1);
    adminVoting.createNewProposal(users.user1, payload);

    // verify requiredWeight is 50.1% majority for setGuardian proposals
    assertEq(adminVoting.getProposalRequiredWeight(0), 
             (tokenLocker.getTotalWeight() * adminVoting.SET_GUARDIAN_PASSING_PCT()) /
             adminVoting.MAX_PCT());

    // fails since the first dummy payload evaded detection of the
    // second setGuardian payload
}
```

Run with: `forge test --match-test test_createNewProposal_setGuardian`

**Recommended Mitigation:**
Rename `AdminVoting::_isSetGuardianPayload` to `_containsSetGuardianPayload` and have it iterate through every element of the payload; if any payload element contains a call to `IBabelCore.setGuardian` then it should enforce the 50.1% requirement for that proposal:
```solidity
function _containsSetGuardianPayload(uint256 payloadLength, Action[] memory payload) internal view returns (bool) {
    for(uint256 i; i<payloadLength; i++) {
        bytes memory data = payload[i].data;

        // Extract the call sig from payload data
        bytes4 sig;
        assembly {
            sig := mload(add(data, 0x20))
        }

        if(sig == IBabelCore.setGuardian.selector) return true;
    }

    return false;
}
```

--------------------------------

**Finding L-6:**
Don't allow cancellation of executed or cancelled proposals

**Description:**
`AdminVoting::cancelProposal` allows cancellation of executed or cancelled proposals which doesn't make logical sense and may mislead guardian as to the exact state of the proposal.

**Recommended Mitigation:**
Prevent cancellation of executed or already cancelled proposals:
```diff
function cancelProposal(uint256 id) external {
    require(msg.sender == babelCore.guardian(), "Only guardian can cancel proposals");
    require(id < proposalData.length, "Invalid ID");

    Action[] storage payload = proposalPayloads[id];
    require(!_containsSetGuardianPayload(payload.length, payload), "Guardian replacement not cancellable");
+   require(!proposalData[id].processed, "Already processed");
    proposalData[id].processed = true;
    emit ProposalCancelled(id);
}
```

--------------------------------

**Finding G-5:**
Refactor `AdminVoting::minCreateProposalWeight` to eliminate unnecessary variables and multiple calls to `getWeek`

**Description:**
Refactor `AdminVoting::minCreateProposalWeight` to eliminate unnecessary variables and multiple calls to `getWeek`:
```solidity
function minCreateProposalWeight() public view returns (uint256 weight) {
    // store getWeek() directly into output `weight` return
    weight = getWeek();

    // if week == 0 nothing else to do since weight also 0
    if(weight != 0) {
        // otherwise over-write output with weight calculation subtracting
        // 1 from the week
        weight = _minCreateProposalWeight(weight-1);
    }
}

// create a new private function called by the public variant and also by `createNewProposal`
function _minCreateProposalWeight(uint256 week) internal view returns (uint256 weight) {
    // store total weight directly into output `weight` return
    weight = tokenLocker.getTotalWeightAt(week);

    // prevent proposal creation if zero total weight for given week
    require(weight > 0, "Zero total voting weight for given week");

    // over-write output return with weight calculation
    weight = (weight * minCreateProposalPct / MAX_PCT);
}

// then change `createNewProposal` to call the new private function passing in the week input
require(accountWeight >= _minCreateProposalWeight(week), "Not enough weight to propose");
```

--------------------------------

Also added:
* some explanatory comments
* minor gas optimizations like using named return variables and removing redundant `return` statements when using named return variables
* lots of new test cases for dao components
* fix for finding M-1, large so not copied here but shared in TG