### PR TITLE
Fix H-1, M-2, L-7, L-8 lots of tests + explanatory comments and minor gas/info fixes

### DIFF
--- a/contracts/core/BorrowerOperations.sol
+++ b/contracts/core/BorrowerOperations.sol
@@ -180,7 +180,11 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
         vars.netDebt = _debtAmount;
 
         if (!isRecoveryMode) {
-            vars.netDebt = vars.netDebt + _triggerBorrowingFee(troveManager, account, _maxFeePercentage, _debtAmount);
+            vars.netDebt = vars.netDebt + _triggerBorrowingFee(troveManager,
+                                                               collateralToken,
+                                                               account,
+                                                               _maxFeePercentage,
+                                                               _debtAmount);
         }
         _requireAtLeastMinNetDebt(vars.netDebt);
 
@@ -339,7 +343,11 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
             _requireValidMaxFeePercentage(_maxFeePercentage);
             if (!isRecoveryMode) {
                 // If the adjustment incorporates a debt increase and system is in Normal Mode, trigger a borrowing fee
-                vars.netDebtChange += _triggerBorrowingFee(troveManager, msg.sender, _maxFeePercentage, _debtChange);
+                vars.netDebtChange += _triggerBorrowingFee(troveManager,
+                                                           collateralToken,
+                                                           msg.sender,
+                                                           _maxFeePercentage,
+                                                           _debtChange);
             }
         }
 
@@ -406,6 +414,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
 
     function _triggerBorrowingFee(
         ITroveManager _troveManager,
+        IERC20 collateralToken,
         address _caller,
         uint256 _maxFeePercentage,
         uint256 _debtAmount
@@ -416,7 +425,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
 
         debtToken.mint(BABEL_CORE.feeReceiver(), debtFee);
 
-        emit BorrowingFeePaid(_caller, debtFee);
+        emit BorrowingFeePaid(_caller, collateralToken, debtFee);
 
         return debtFee;
     }

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -439,7 +439,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         require(msg.sender == address(this), "Only callable via proposal");
 
         // restrict max value
-        require(pct <= MAX_PCT, "Invalid value");
+        require(pct <= MAX_PCT && pct > 0, "Invalid value");
 
         // update to new value
         passingPct = pct;

--- a/contracts/dao/AllocationVesting.sol
+++ b/contracts/dao/AllocationVesting.sol
@@ -44,7 +44,7 @@ contract AllocationVesting is DelegatedOps, Ownable {
     // This number should allow a good precision in allocation fractions
     uint256 private constant TOTAL_POINTS = 100000;
     // Users allocations
-    mapping(address => AllocationState) public allocations;
+    mapping(address recipient => AllocationState) public allocations;
     // max percentage of one's vest that can be preclaimed in total
     uint256 public immutable maxTotalPreclaimPct;
     // Total allocation expressed in tokens

--- a/contracts/dao/AllocationVesting.sol
+++ b/contracts/dao/AllocationVesting.sol
@@ -168,8 +168,10 @@ contract AllocationVesting is DelegatedOps, Ownable {
         uint96 preclaimedToTransfer = SafeCast.toUint96((uint256(fromAllocation.preclaimed) * points) /
                                                         fromAllocation.points);
 
-        allocations[to].preclaimed = toAllocation.preclaimed + preclaimedToTransfer;
-        allocations[from].preclaimed = fromAllocation.preclaimed - preclaimedToTransfer;
+        if(preclaimedToTransfer > 0) {
+            allocations[to].preclaimed = toAllocation.preclaimed + preclaimedToTransfer;
+            allocations[from].preclaimed = fromAllocation.preclaimed - preclaimedToTransfer;
+        }
         
         // update storage - deduct points from `from` using memory cache
         allocations[from].points = fromAllocation.points - points;

--- a/contracts/dao/AllocationVesting.sol
+++ b/contracts/dao/AllocationVesting.sol
@@ -162,6 +162,14 @@ contract AllocationVesting is DelegatedOps, Ownable {
 
         // passive balance to transfer
         uint128 claimedAdjustment = SafeCast.toUint128((claimed * points) / fromAllocation.points);
+
+        // update storage - transfer preclaimed amounts to prevent point transfers
+        // being used to bypass the maximum preclaim limit
+        uint96 preclaimedToTransfer = SafeCast.toUint96((uint256(fromAllocation.preclaimed) * points) /
+                                                        fromAllocation.points);
+
+        allocations[to].preclaimed = toAllocation.preclaimed + preclaimedToTransfer;
+        allocations[from].preclaimed = fromAllocation.preclaimed - preclaimedToTransfer;
         
         // update storage - deduct points from `from` using memory cache
         allocations[from].points = fromAllocation.points - points;

--- a/contracts/dao/BoostCalculator.sol
+++ b/contracts/dao/BoostCalculator.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.19;
 import {IBoostCalculator, ITokenLocker} from "../interfaces/IBoostCalculator.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 /**
     @title Babel Boost Calculator
     @notice "Boost" refers to a bonus to claimable BABEL tokens that an account
@@ -50,13 +52,19 @@ import {SystemStart} from "../dependencies/SystemStart.sol";
 contract BoostCalculator is IBoostCalculator, SystemStart {
     ITokenLocker public immutable locker;
 
+    // constants used
+    // use 1 to indicate no lock weight -> no boost
+    uint256 internal constant NO_LOCK_WEIGHT = 1;
+    // used to scale values during % calculation represents 100%
+    uint256 internal constant SCALE_FACTOR = 1e9;
+
     // initial number of weeks where all accounts recieve max boost
     uint256 public immutable MAX_BOOST_GRACE_WEEKS;
 
     // week -> total weekly lock weight
     // tracked locally to avoid repeated external calls
     uint40[65535] totalWeeklyWeights;
-    // account -> week -> % of lock weight (where 1e9 represents 100%)
+    // account -> week -> % of lock weight (where SCALE_FACTOR represents 100%)
     mapping(address account => uint32[65535] weeklyLockPercent) accountWeeklyLockPct;
 
     constructor(address _babelCore, ITokenLocker _locker, uint256 _graceWeeks) SystemStart(_babelCore) {
@@ -79,16 +87,37 @@ contract BoostCalculator is IBoostCalculator, SystemStart {
         uint256 previousAmount,
         uint256 totalWeeklyEmissions
     ) external view returns (uint256 adjustedAmount) {
+        // get current system week
         uint256 week = getWeek();
+
+        // if current system week < than max boost end grace week
+        // return the input amount
         if (week < MAX_BOOST_GRACE_WEEKS) return amount;
+
+        // go back one week before current system week
         week -= 1;
 
+        // get account locked weight one week before current system week
         uint256 accountWeight = locker.getAccountWeightAt(account, week);
+
+        // get total locked weight one week before current system week
         uint256 totalWeight = locker.getTotalWeightAt(week);
+
+        // if there was no locked weight, use value of 1 to prevent
+        // division by 0
+        //
+        // note: should never be possible for accountWeight > 0 but
+        // totalWeight == 0 in the same week
         if (totalWeight == 0) totalWeight = 1;
-        uint256 pct = (1e9 * accountWeight) / totalWeight;
-        if (pct == 0) pct = 1;
-        return _getBoostedAmount(amount, previousAmount, totalWeeklyEmissions, pct);
+
+        // calculate % account had of total weight that week
+        uint256 pct = (SCALE_FACTOR * accountWeight) / totalWeight;
+
+        // 0 = none
+        if (pct == 0) pct = NO_LOCK_WEIGHT;
+
+        // output boosted amount
+        adjustedAmount = _getBoostedAmount(amount, previousAmount, totalWeeklyEmissions, pct);
     }
 
     /**
@@ -104,26 +133,56 @@ contract BoostCalculator is IBoostCalculator, SystemStart {
         uint256 previousAmount,
         uint256 totalWeeklyEmissions
     ) external view returns (uint256 maxBoosted, uint256 boosted) {
+        // get current system week
         uint256 week = getWeek();
+
+        // if current system week < than max boost end grace week
+        // return remaining amount for the current week
         if (week < MAX_BOOST_GRACE_WEEKS) {
-            uint256 remaining = totalWeeklyEmissions - previousAmount;
-            return (remaining, remaining);
+            maxBoosted = totalWeeklyEmissions - previousAmount;
+            boosted = maxBoosted;
         }
-        week -= 1;
+        else {
+            // otherwise go back one week before current system week
+            week -= 1;
 
-        uint256 accountWeight = locker.getAccountWeightAt(claimant, week);
-        uint256 totalWeight = locker.getTotalWeightAt(week);
-        if (totalWeight == 0) totalWeight = 1;
-        uint256 pct = (1e9 * accountWeight) / totalWeight;
-        if (pct == 0) return (0, 0);
+            // get account locked weight one week before current system week
+            uint256 accountWeight = locker.getAccountWeightAt(claimant, week);
 
-        uint256 maxBoostable = (totalWeeklyEmissions * pct) / 1e9;
-        uint256 fullDecay = maxBoostable * 2;
+            // get total locked weight one week before current system week
+            uint256 totalWeight = locker.getTotalWeightAt(week);
 
-        return (
-            previousAmount >= maxBoostable ? 0 : maxBoostable - previousAmount,
-            previousAmount >= fullDecay ? 0 : fullDecay - maxBoostable
-        );
+            // if there was no locked weight, use value of 1 to prevent
+            // division by 0
+            //
+            // note: should never be possible for accountWeight > 0 but
+            // totalWeight == 0 in the same week
+            if (totalWeight == 0) totalWeight = 1;
+
+            // calculate % account had of total weight that week
+            uint256 pct = (SCALE_FACTOR * accountWeight) / totalWeight;
+
+            // if account had 0%, give them 0; since output variables are
+            // initialized to default values, no need to explicit return
+            if(pct != 0) {
+                // otherwise account had > 0 pct of weekly weight so
+                // perform additional processing
+
+                // calculate account's max boostable and decay
+                uint256 maxBoostable = (totalWeeklyEmissions * pct) / SCALE_FACTOR;
+                uint256 fullDecay = maxBoostable * 2;
+
+                // output maxBoosted
+                // if previous claimed >= max boostable then 0, otherwise difference
+                // between max boostable and previous claimed
+                maxBoosted = previousAmount >= maxBoostable ? 0 : maxBoostable - previousAmount;
+
+                // output boosted
+                // if previous claimed >= decay then 0, otherwise difference between
+                // decay and max boostable
+                boosted = previousAmount >= fullDecay ? 0 : fullDecay - maxBoostable;
+            }
+        }
     }
 
     /**
@@ -141,26 +200,50 @@ contract BoostCalculator is IBoostCalculator, SystemStart {
         uint256 previousAmount,
         uint256 totalWeeklyEmissions
     ) external returns (uint256 adjustedAmount) {
+        // get current system week
         uint256 week = getWeek();
+
+        // if current system week < than max boost end grace week
+        // return the input amount
         if (week < MAX_BOOST_GRACE_WEEKS) return amount;
+
+        // otherwise go back one week before current system week
         week -= 1;
 
+        // cache storage account lock % for that week
         uint256 pct = accountWeeklyLockPct[account][week];
+
+        // if 0, calculate it
         if (pct == 0) {
+            // cache total locked weight storage for that week
             uint256 totalWeight = totalWeeklyWeights[week];
+
+            // if 0, fetch and store it
             if (totalWeight == 0) {
                 totalWeight = locker.getTotalWeightAt(week);
+
+                // if 0, use minimum 1 to prevent division by zero
                 if (totalWeight == 0) totalWeight = 1;
-                totalWeeklyWeights[week] = uint40(totalWeight);
+
+                // update storage total weight for that week
+                totalWeeklyWeights[week] = SafeCast.toUint40(totalWeight);
             }
 
+            // fetch account weight for that week
             uint256 accountWeight = locker.getAccountWeightAt(account, week);
-            pct = (1e9 * accountWeight) / totalWeight;
-            if (pct == 0) pct = 1;
-            accountWeeklyLockPct[account][week] = uint32(pct);
+
+            // calculate % account had of total weight that week
+            pct = (SCALE_FACTOR * accountWeight) / totalWeight;
+
+            // 0 = none
+            if (pct == 0) pct = NO_LOCK_WEIGHT;
+
+            // update storage account % of locked weight for that week
+            accountWeeklyLockPct[account][week] = SafeCast.toUint32(pct);
         }
 
-        return _getBoostedAmount(amount, previousAmount, totalWeeklyEmissions, pct);
+        // output boosted amount
+        adjustedAmount = _getBoostedAmount(amount, previousAmount, totalWeeklyEmissions, pct);
     }
 
     function _getBoostedAmount(
@@ -169,11 +252,11 @@ contract BoostCalculator is IBoostCalculator, SystemStart {
         uint256 totalWeeklyEmissions,
         uint256 pct
     ) internal pure returns (uint256 adjustedAmount) {
-        // we use 1 to indicate no lock weight: no boost
-        if (pct == 1) return amount / 2;
+        // if account had no lock weight return half input amount
+        if (pct == NO_LOCK_WEIGHT) return amount / 2;
 
         uint256 total = amount + previousAmount;
-        uint256 maxBoostable = (totalWeeklyEmissions * pct) / 1e9;
+        uint256 maxBoostable = (totalWeeklyEmissions * pct) / SCALE_FACTOR;
         uint256 fullDecay = maxBoostable * 2;
 
         // entire claim receives max boost
@@ -208,7 +291,5 @@ contract BoostCalculator is IBoostCalculator, SystemStart {
         uint256 initialBoosted = amount - (amount * (previousAmount - maxBoostable)) / maxBoostable / 2;
         // with linear decay, adjusted amount is half of the difference between initial and final boost amounts
         adjustedAmount += (initialBoosted - finalBoosted) / 2;
-
-        return adjustedAmount;
     }
 }

--- a/contracts/dao/BoostCalculator.sol
+++ b/contracts/dao/BoostCalculator.sol
@@ -57,7 +57,7 @@ contract BoostCalculator is IBoostCalculator, SystemStart {
     // tracked locally to avoid repeated external calls
     uint40[65535] totalWeeklyWeights;
     // account -> week -> % of lock weight (where 1e9 represents 100%)
-    mapping(address account => uint32[65535]) accountWeeklyLockPct;
+    mapping(address account => uint32[65535] weeklyLockPercent) accountWeeklyLockPct;
 
     constructor(address _babelCore, ITokenLocker _locker, uint256 _graceWeeks) SystemStart(_babelCore) {
         require(_graceWeeks > 0, "Grace weeks cannot be 0");

--- a/contracts/dao/EmissionSchedule.sol
+++ b/contracts/dao/EmissionSchedule.sol
@@ -88,10 +88,16 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
         uint256 id,
         uint256 week,
         uint256 totalWeeklyEmissions
-    ) external returns (uint256) {
-        uint256 pct = voter.getReceiverVotePct(id, week);
+    ) external returns (uint256 amount) {
+        // get vote calculation inputs from IncentiveVoting
+        (uint256 totalWeeklyWeight, uint256 receiverWeeklyWeight)
+            = voter.getReceiverVoteInputs(id, week);
 
-        return (totalWeeklyEmissions * pct) / 1e18;
+        // if there was weekly weight, calculate the amount
+        // otherwise default returns 0
+        if(totalWeeklyWeight != 0) {
+            amount = totalWeeklyEmissions * receiverWeeklyWeight / totalWeeklyWeight;
+        }
     }
 
     function getTotalWeeklyEmissions(

--- a/contracts/dao/EmissionSchedule.sol
+++ b/contracts/dao/EmissionSchedule.sol
@@ -97,9 +97,8 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
     function getTotalWeeklyEmissions(
         uint256 week,
         uint256 unallocatedTotal
-    ) external returns (uint256 amount, uint256 lock) {
+    ) external returns (uint256 amount, uint64 lock) {
         // only vault can call this function
-        // vault always calls this function for current getWeek()
         require(msg.sender == address(vault));
 
         // apply the lock week decay
@@ -112,7 +111,7 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
         if (lock > 0 && week % lockDecayWeeks == 0) {
             // then decrement current weeks to lock for
             lock -= 1;
-            lockWeeks = uint64(lock);
+            lockWeeks = lock;
 
             // note: checks inside `BabelVault::_allocateTotalWeekly`
             // prevent this function being called multiple times

--- a/contracts/dao/EmissionSchedule.sol
+++ b/contracts/dao/EmissionSchedule.sol
@@ -99,6 +99,7 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
         uint256 unallocatedTotal
     ) external returns (uint256 amount, uint256 lock) {
         // only vault can call this function
+        // vault always calls this function for current getWeek()
         require(msg.sender == address(vault));
 
         // apply the lock week decay
@@ -112,6 +113,10 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
             // then decrement current weeks to lock for
             lock -= 1;
             lockWeeks = uint64(lock);
+
+            // note: checks inside `BabelVault::_allocateTotalWeekly`
+            // prevent this function being called multiple times
+            // for the same week
         }
 
         // check for and apply scheduled update to `weeklyPct`

--- a/contracts/dao/IncentiveVoting.sol
+++ b/contracts/dao/IncentiveVoting.sol
@@ -229,6 +229,25 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         }
     }
 
+    function getReceiverVoteInputs(uint256 id, uint256 week) external 
+    returns (uint256 totalWeeklyWeight, uint256 receiverWeeklyWeight) {
+        // lookback one week
+        week -= 1;
+
+        // update storage - id & total weights for any
+        // missing weeks up to current system week
+        getReceiverWeightWrite(id);
+        getTotalWeightWrite();
+
+        // output total weight for lookback week
+        totalWeeklyWeight = totalWeeklyWeights[week];
+
+        // if not zero, also output receiver weekly weight
+        if(totalWeeklyWeight != 0) {
+            receiverWeeklyWeight = receiverWeeklyWeights[id][week];
+        }
+    }
+
     function getReceiverVotePct(uint256 id, uint256 week) external returns (uint256 votePct) {
         // lookback one week
         week -= 1;

--- a/contracts/dao/IncentiveVoting.sol
+++ b/contracts/dao/IncentiveVoting.sol
@@ -41,7 +41,7 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         uint8[MAX_LOCK_WEEKS] weeksToUnlock;
     }
 
-    mapping(address => AccountData) accountLockData;
+    mapping(address account => AccountData lockData) accountLockData;
 
     uint256 public receiverCount;
     // id -> receiver data

--- a/contracts/dao/IncentiveVoting.sol
+++ b/contracts/dao/IncentiveVoting.sol
@@ -5,6 +5,8 @@ import {DelegatedOps} from "../dependencies/DelegatedOps.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
 import {IIncentiveVoting, ITokenLocker} from "../interfaces/IIncentiveVoting.sol";
 
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
+
 /**
     @title Babel Incentive Voting
     @notice Users with BABEL balances locked in `TokenLocker` may register their
@@ -65,7 +67,8 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
     function getAccountRegisteredLocks(
         address account
     ) external view returns (uint256 frozenWeight, ITokenLocker.LockData[] memory lockData) {
-        return (accountLockData[account].frozenWeight, _getAccountLocks(account));
+        frozenWeight = accountLockData[account].frozenWeight;
+        lockData = _getAccountLocks(account);
     }
 
     function getAccountCurrentVotes(address account) public view returns (Vote[] memory votes) {
@@ -75,117 +78,186 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         for (uint256 i; i < length; i++) {
             votes[i] = Vote({ id: storedVotes[i][0], points: storedVotes[i][1] });
         }
-        return votes;
     }
 
-    function getReceiverWeight(uint256 idx) external view returns (uint256) {
-        return getReceiverWeightAt(idx, getWeek());
+    function getReceiverWeight(uint256 idx) external view returns (uint256 weight) {
+        weight = getReceiverWeightAt(idx, getWeek());
     }
 
-    function getReceiverWeightAt(uint256 idx, uint256 week) public view returns (uint256) {
-        if (idx >= receiverCount) return 0;
-        uint256 rate = receiverDecayRate[idx];
-        uint256 updatedWeek = receiverUpdatedWeek[idx];
-        if (week <= updatedWeek) return receiverWeeklyWeights[idx][week];
+    function getReceiverWeightAt(uint256 idx, uint256 week) public view returns (uint256 weight) {
+        // if idx >= receiver count nothing to do, default 0 will be returned
+        if(idx < receiverCount) {
+            // get last updated week for input idx
+            uint256 updatedWeek = receiverUpdatedWeek[idx];
 
-        uint256 weight = receiverWeeklyWeights[idx][updatedWeek];
-        if (weight == 0) return 0;
+            // if input week has already been processed, return answer from storage
+            if (week <= updatedWeek) return receiverWeeklyWeights[idx][week];
 
-        while (updatedWeek < week) {
-            updatedWeek++;
-            weight -= rate;
-            rate -= receiverWeeklyUnlocks[idx][updatedWeek];
+            // otherwise read weight from idx's last updated week
+            weight = receiverWeeklyWeights[idx][updatedWeek];
+
+            // if not 0, perform additional processing
+            if (weight != 0) {
+                // cache decay rate from idx storage
+                uint256 rate = receiverDecayRate[idx];
+
+                // iterate over unprocessed weeks until input week,
+                // adjusting the weight by decay rate and decay
+                // rate by weekly unlocks
+                while (updatedWeek < week) {
+                    updatedWeek++;
+                    weight -= rate;
+                    rate -= receiverWeeklyUnlocks[idx][updatedWeek];
+                }
+            }
         }
-
-        return weight;
     }
 
-    function getTotalWeight() external view returns (uint256) {
-        return getTotalWeightAt(getWeek());
+    function getTotalWeight() external view returns (uint256 weight) {
+        weight = getTotalWeightAt(getWeek());
     }
 
-    function getTotalWeightAt(uint256 week) public view returns (uint256) {
-        uint256 rate = totalDecayRate;
+    function getTotalWeightAt(uint256 week) public view returns (uint256 weight) {
+        // get last updated week for total weight
         uint256 updatedWeek = totalUpdatedWeek;
+
+        // if input week has already been processed, return answer from storage
         if (week <= updatedWeek) return totalWeeklyWeights[week];
 
-        uint256 weight = totalWeeklyWeights[updatedWeek];
-        if (weight == 0) return 0;
+        // otherwise read weight from total weight's last updated week
+        weight = totalWeeklyWeights[updatedWeek];
 
-        while (updatedWeek < week) {
-            updatedWeek++;
-            weight -= rate;
-            rate -= totalWeeklyUnlocks[updatedWeek];
+        // if not 0, perform additional processing
+        if (weight != 0) {
+            // cache total decay rate from storage; this represents the
+            // rate at the last updated week so is the correct rate to
+            // start from
+            uint256 rate = totalDecayRate;
+
+            // iterate over unprocessed weeks until input week,
+            // adjusting the weight by decay rate and decay
+            // rate by weekly unlocks
+            while (updatedWeek < week) {
+                updatedWeek++;
+                weight -= rate;
+                rate -= totalWeeklyUnlocks[updatedWeek];
+            }
         }
-        return weight;
     }
 
-    function getReceiverWeightWrite(uint256 idx) public returns (uint256) {
+    function getReceiverWeightWrite(uint256 idx) public returns (uint256 weight) {
+        // revert for invalid idx
         require(idx < receiverCount, "Invalid ID");
+
+        // get current system week
         uint256 week = getWeek();
+
+        // get last updated week for input idx
         uint256 updatedWeek = receiverUpdatedWeek[idx];
-        uint256 weight = receiverWeeklyWeights[idx][updatedWeek];
 
+        // output weight from idx's last updated week
+        weight = receiverWeeklyWeights[idx][updatedWeek];
+
+        // if zero, just update the idx last updated week
+        // to the current system week
         if (weight == 0) {
-            receiverUpdatedWeek[idx] = uint16(week);
-            return 0;
+            receiverUpdatedWeek[idx] = SafeCast.toUint16(week);
         }
+        // otherwise perform additional processing
+        else {
+            // cache decay rate from idx storage
+            uint256 rate = receiverDecayRate[idx];
 
-        uint256 rate = receiverDecayRate[idx];
-        while (updatedWeek < week) {
-            updatedWeek++;
-            weight -= rate;
-            receiverWeeklyWeights[idx][updatedWeek] = uint40(weight);
-            rate -= receiverWeeklyUnlocks[idx][updatedWeek];
+            // iterate over unprocessed weeks until current system
+            // week, adjusting the weight by decay rate and decay
+            // rate by weekly unlocks
+            while (updatedWeek < week) {
+                updatedWeek++;
+                weight -= rate;
+                // update storage weekly idx weight
+                receiverWeeklyWeights[idx][updatedWeek] = SafeCast.toUint40(weight);
+
+                // adjust rate by weekly unlocks
+                rate -= receiverWeeklyUnlocks[idx][updatedWeek];
+            }
+
+            // finally update idx decay rate and last processed week
+            receiverDecayRate[idx] = SafeCast.toUint32(rate);
+            receiverUpdatedWeek[idx] = SafeCast.toUint16(week);
         }
-
-        receiverDecayRate[idx] = uint32(rate);
-        receiverUpdatedWeek[idx] = uint16(week);
-
-        return weight;
     }
 
-    function getTotalWeightWrite() public returns (uint256) {
+    function getTotalWeightWrite() public returns (uint256 weight) {
+        // get current system week
         uint256 week = getWeek();
+
+        // get last updated week for total weight
         uint256 updatedWeek = totalUpdatedWeek;
-        uint256 weight = totalWeeklyWeights[updatedWeek];
 
+        // output weight from total weight's last updated week
+        weight = totalWeeklyWeights[updatedWeek];
+
+        // if zero, just update the total weight last updated week
+        // to the current system week
         if (weight == 0) {
-            totalUpdatedWeek = uint16(week);
-            return 0;
+            totalUpdatedWeek = SafeCast.toUint16(week);
         }
+        // otherwise perform additional processing
+        else {
+            // cache total decay rate from storage; this represents the
+            // rate at the last updated week so is the correct rate to
+            // start from
+            uint256 rate = totalDecayRate;
 
-        uint256 rate = totalDecayRate;
-        while (updatedWeek < week) {
-            updatedWeek++;
-            weight -= rate;
-            totalWeeklyWeights[updatedWeek] = uint40(weight);
-            rate -= totalWeeklyUnlocks[updatedWeek];
+            // iterate over unprocessed weeks until current system week,
+            // adjusting the weight by decay rate and decay rate by weekly
+            // unlocks
+            while (updatedWeek < week) {
+                updatedWeek++;
+                weight -= rate;
+
+                // update storage weekly total weight
+                totalWeeklyWeights[updatedWeek] = SafeCast.toUint40(weight);
+
+                // adjust rate by weekly unlocks
+                rate -= totalWeeklyUnlocks[updatedWeek];
+            }
+
+            // finally update total decay rate and last processed week
+            totalDecayRate = SafeCast.toUint32(rate);
+            totalUpdatedWeek = SafeCast.toUint16(week);
         }
-
-        totalDecayRate = uint32(rate);
-        totalUpdatedWeek = uint16(week);
-
-        return weight;
     }
 
-    function getReceiverVotePct(uint256 id, uint256 week) external returns (uint256) {
+    function getReceiverVotePct(uint256 id, uint256 week) external returns (uint256 votePct) {
+        // lookback one week
         week -= 1;
+
+        // update storage - id & total weights for any
+        // missing weeks up to current system week
         getReceiverWeightWrite(id);
         getTotalWeightWrite();
 
-        uint256 totalWeight = totalWeeklyWeights[week];
-        if (totalWeight == 0) return 0;
+        // output total weight for lookback week
+        votePct = totalWeeklyWeights[week];
 
-        return (1e18 * uint256(receiverWeeklyWeights[id][week])) / totalWeight;
+        // if not zero, calculate the actual vote percent
+        // for the lookback week; using votePct as denominator
+        // since it contains the totalWeight
+        if(votePct != 0) {
+            votePct = 1e18 * uint256(receiverWeeklyWeights[id][week]) / votePct;
+        }
     }
 
-    function registerNewReceiver() external returns (uint256) {
+    function registerNewReceiver() external returns (uint256 id) {
+        // only vault can register new receivers
         require(msg.sender == vault, "Not Treasury");
-        uint256 id = receiverCount;
-        receiverUpdatedWeek[id] = uint16(getWeek());
-        receiverCount = id + 1;
-        return id;
+
+        // output current value then increment storage
+        id = receiverCount++;
+
+        // set last processed week to current system week
+        receiverUpdatedWeek[id] = SafeCast.toUint16(getWeek());
     }
 
     /**
@@ -197,7 +269,9 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
                         locks may wish to skip smaller locks to reduce gas costs.
      */
     function registerAccountWeight(address account, uint256 minWeeks) external callerOrDelegated(account) {
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
+
         Vote[] memory existingVotes;
 
         // if account has an active vote, clear the recorded vote
@@ -226,6 +300,7 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         uint256 minWeeks,
         Vote[] calldata votes
     ) external callerOrDelegated(account) {
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
 
         // if account has an active vote, clear the recorded vote
@@ -259,9 +334,16 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
                              votes are added in addition to previous votes.
      */
     function vote(address account, Vote[] calldata votes, bool clearPrevious) external callerOrDelegated(account) {
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
+
+        // cache account's frozen weight
         uint256 frozenWeight = accountData.frozenWeight;
+
+        // revert if no frozen weight or no locks
         require(frozenWeight > 0 || accountData.lockLength > 0, "No registered weight");
+
+        // working data
         uint256 points;
         uint256 offset;
 
@@ -284,9 +366,16 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         @notice Remove all active votes for the caller
      */
     function clearVote(address account) external callerOrDelegated(account) {
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
+
+        // cache account's frozen weight
         uint256 frozenWeight = accountData.frozenWeight;
+
+        // clear account's current votes
         _removeVoteWeights(account, getAccountCurrentVotes(account), frozenWeight);
+
+        // reset voteLength & points
         accountData.voteLength = 0;
         accountData.points = 0;
 
@@ -298,23 +387,35 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         @dev Called by `tokenLocker` when an account performs an early withdrawal
              of locked tokens, to prevent a registered weight > actual lock weight
      */
-    function clearRegisteredWeight(address account) external returns (bool) {
+    function clearRegisteredWeight(address account) external returns (bool success) {
         require(
-            msg.sender == account || msg.sender == address(tokenLocker) || isApprovedDelegate[account][msg.sender],
+            msg.sender == account || msg.sender == address(tokenLocker) ||
+            isApprovedDelegate[account][msg.sender],
             "Delegate not approved"
         );
 
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
+
+        // get current system week
         uint256 week = getWeek();
+
+        // cache number of account's locks
         uint256 length = accountData.lockLength;
+
+        // cache account's frozen weight
         uint256 frozenWeight = accountData.frozenWeight;
+
         if (length > 0 || frozenWeight > 0) {
+            // clear any current votes
             if (accountData.voteLength > 0) {
                 _removeVoteWeights(account, getAccountCurrentVotes(account), frozenWeight);
                 accountData.voteLength = 0;
                 accountData.points = 0;
+
                 emit ClearedVotes(account, week);
             }
+
             // lockLength and frozenWeight are never both > 0
             if (length > 0) accountData.lockLength = 0;
             else accountData.frozenWeight = 0;
@@ -322,7 +423,7 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
             emit AccountWeightRegistered(account, week, 0, new ITokenLocker.LockData[](0));
         }
 
-        return true;
+        success = true;
     }
 
     /**
@@ -331,26 +432,34 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
              registering frozen locks, unfreezing, and having a larger registered
              vote weight than their actual lock weight.
      */
-    function unfreeze(address account, bool keepVote) external returns (bool) {
+    function unfreeze(address account, bool keepVote) external returns (bool success) {
+        // only tokenLocker can call this function
         require(msg.sender == address(tokenLocker));
+
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
+
+        // cache account's frozen weight
         uint256 frozenWeight = accountData.frozenWeight;
 
         // if frozenWeight == 0, the account was not registered so nothing needed
         if (frozenWeight > 0) {
             // clear previous votes
             Vote[] memory existingVotes;
+
             if (accountData.voteLength > 0) {
                 existingVotes = getAccountCurrentVotes(account);
                 _removeVoteWeightsFrozen(existingVotes, frozenWeight);
             }
 
+            // get current system week
             uint256 week = getWeek();
-            accountData.week = uint16(week);
+
+            accountData.week = SafeCast.toUint16(week);
             accountData.frozenWeight = 0;
 
             uint256 amount = frozenWeight / MAX_LOCK_WEEKS;
-            accountData.lockedAmounts[0] = uint32(amount);
+            accountData.lockedAmounts[0] = SafeCast.toUint32(amount);
             accountData.weeksToUnlock[0] = uint8(MAX_LOCK_WEEKS);
             accountData.lockLength = 1;
 
@@ -369,7 +478,8 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
             lockData[0] = ITokenLocker.LockData({ amount: amount, weeksToUnlock: MAX_LOCK_WEEKS });
             emit AccountWeightRegistered(account, week, 0, lockData);
         }
-        return true;
+
+        success = true;
     }
 
     /**
@@ -377,61 +487,83 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
              of [(amount, weeks to unlock)] sorted by weeks-to-unlock descending.
      */
     function _getAccountLocks(address account) internal view returns (ITokenLocker.LockData[] memory lockData) {
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
 
+        // cache number of account's locks
         uint256 length = accountData.lockLength;
+
+        // get current system week
         uint256 systemWeek = getWeek();
+
+        // if account has frozen weight use system week
+        // else use account's last processed week
         uint256 accountWeek = accountData.frozenWeight > 0 ? systemWeek : accountData.week;
+
+        // get storage references to account's unlock weeks & locked amounts
         uint8[MAX_LOCK_WEEKS] storage weeksToUnlock = accountData.weeksToUnlock;
         uint32[MAX_LOCK_WEEKS] storage amounts = accountData.lockedAmounts;
 
+        // allocate output array
         lockData = new ITokenLocker.LockData[](length);
+
         uint256 idx;
         for (; idx < length; idx++) {
+            // calculate the unlock week for this lock
             uint256 unlockWeek = weeksToUnlock[idx] + accountWeek;
+
             if (unlockWeek <= systemWeek) {
                 assembly {
                     mstore(lockData, idx)
                 }
                 break;
             }
-            uint256 remainingWeeks = unlockWeek - systemWeek;
-            uint256 amount = amounts[idx];
-            lockData[idx] = ITokenLocker.LockData({ amount: amount, weeksToUnlock: remainingWeeks });
-        }
 
-        return lockData;
+            lockData[idx] = ITokenLocker.LockData({ amount: amounts[idx],
+                                                    weeksToUnlock: unlockWeek - systemWeek });
+        }
     }
 
-    function _registerAccountWeight(address account, uint256 minWeeks) internal returns (uint256) {
+    function _registerAccountWeight(address account, uint256 minWeeks) internal returns (uint256 frozen) {
+        // get storage reference to account's lock data
         AccountData storage accountData = accountLockData[account];
 
-        // get updated account lock weights and store locally
-        (ITokenLocker.LockData[] memory lockData, uint256 frozen) = tokenLocker.getAccountActiveLocks(
-            account,
-            minWeeks
-        );
+        ITokenLocker.LockData[] memory lockData;
+
+        // get latest account lock weights from TokenLocker and store locally
+        (lockData, frozen) = tokenLocker.getAccountActiveLocks(account, minWeeks);
+
+        // cache number of locks
         uint256 length = lockData.length;
+
+        // if frozen, multiply by max lock weeks and
+        // update storage account frozen weight
         if (frozen > 0) {
             frozen *= MAX_LOCK_WEEKS;
-            accountData.frozenWeight = uint40(frozen);
-        } else if (length > 0) {
+            accountData.frozenWeight = SafeCast.toUint40(frozen);
+        }
+        // else if there are active locks iterate through them
+        // updating storage account locked amounts and weeks to unlock
+        else if (length > 0) {
             for (uint256 i; i < length; i++) {
-                uint256 amount = lockData[i].amount;
-                uint256 weeksToUnlock = lockData[i].weeksToUnlock;
-                accountData.lockedAmounts[i] = uint32(amount);
-                accountData.weeksToUnlock[i] = uint8(weeksToUnlock);
+                accountData.lockedAmounts[i] = SafeCast.toUint32(lockData[i].amount);
+                accountData.weeksToUnlock[i] = SafeCast.toUint8(lockData[i].weeksToUnlock);
             }
-        } else {
+        }
+        // revert if nothing frozen and no active locks
+        else {
             revert("No active locks");
         }
-        uint256 week = getWeek();
-        accountData.week = uint16(week);
-        accountData.lockLength = uint8(length);
 
-        emit AccountWeightRegistered(account, week, frozen, lockData);
+        // get current system week
+        uint256 systemWeek = getWeek();
 
-        return frozen;
+        // update storage account latest processed week to current system
+        // week and lock length to latest locks processed from TokenLocker
+        accountData.week = SafeCast.toUint16(systemWeek);
+        accountData.lockLength = SafeCast.toUint8(length);
+
+        emit AccountWeightRegistered(account, systemWeek, frozen, lockData);
     }
 
     function _storeAccountVotes(
@@ -441,15 +573,22 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         uint256 points,
         uint256 offset
     ) internal {
+        // get storage reference to account's active votes
         uint16[2][MAX_POINTS] storage storedVotes = accountData.activeVotes;
-        uint256 length = votes.length;
-        for (uint256 i; i < length; i++) {
-            storedVotes[offset + i] = [uint16(votes[i].id), uint16(votes[i].points)];
+
+        // iterate through votes input, cheaper to not
+        // cache length since calldata
+        for (uint256 i; i < votes.length; i++) {
+            // record each vote
+            storedVotes[offset + i] = [SafeCast.toUint16(votes[i].id),
+                                        SafeCast.toUint16(votes[i].points)];
             points += votes[i].points;
         }
+
         require(points <= MAX_POINTS, "Exceeded max vote points");
-        accountData.voteLength = uint16(offset + length);
-        accountData.points = uint16(points);
+
+        accountData.voteLength = SafeCast.toUint16(offset + votes.length);
+        accountData.points = SafeCast.toUint16(points);
 
         emit NewVotes(account, getWeek(), votes, points);
     }
@@ -486,117 +625,182 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
 
     /** @dev Should not be called directly, use `_addVoteWeights` */
     function _addVoteWeightsUnfrozen(address account, Vote[] memory votes) internal {
+        // get account locks from TokenLocker
         ITokenLocker.LockData[] memory lockData = _getAccountLocks(account);
+
+        // cache number of locks
         uint256 lockLength = lockData.length;
+
+        // revert if no locks
         require(lockLength > 0, "Registered weight has expired");
 
+        // working data
         uint256 totalWeight;
         uint256 totalDecay;
         uint256 systemWeek = getWeek();
         uint256[MAX_LOCK_WEEKS + 1] memory weeklyUnlocks;
-        for (uint256 i; i < votes.length; i++) {
-            uint256 id = votes[i].id;
-            uint256 points = votes[i].points;
 
+        // iterate through every vote
+        for (uint256 i; i < votes.length; i++) {
+            (uint256 id, uint256 points) = (votes[i].id, votes[i].points);
+
+            // working data
             uint256 weight;
             uint256 decayRate;
+
+            // for every vote, iterate through every lock
             for (uint256 x; x < lockLength; x++) {
                 uint256 weeksToUnlock = lockData[x].weeksToUnlock;
                 uint256 amount = (lockData[x].amount * points) / MAX_POINTS;
-                receiverWeeklyUnlocks[id][systemWeek + weeksToUnlock] += uint32(amount);
 
-                weeklyUnlocks[weeksToUnlock] += uint32(amount);
+                // updating storage receiver weekly unlocks
+                receiverWeeklyUnlocks[id][systemWeek + weeksToUnlock] += SafeCast.toUint32(amount);
+
+                // update working data
+                weeklyUnlocks[weeksToUnlock] += SafeCast.toUint32(amount);
                 weight += amount * weeksToUnlock;
                 decayRate += amount;
             }
-            receiverWeeklyWeights[id][systemWeek] = uint40(getReceiverWeightWrite(id) + weight);
-            receiverDecayRate[id] += uint32(decayRate);
 
+            // update storage receiver weekly weights and decay rate
+            receiverWeeklyWeights[id][systemWeek] = SafeCast.toUint40(getReceiverWeightWrite(id) + weight);
+            receiverDecayRate[id] += SafeCast.toUint32(decayRate);
+
+            // update working data
             totalWeight += weight;
             totalDecay += decayRate;
         }
 
+        // iterate through every lock updating storage total weekly unlocks
         for (uint256 i; i < lockLength; i++) {
             uint256 weeksToUnlock = lockData[i].weeksToUnlock;
-            totalWeeklyUnlocks[systemWeek + weeksToUnlock] += uint32(weeklyUnlocks[weeksToUnlock]);
+            totalWeeklyUnlocks[systemWeek + weeksToUnlock]
+                += SafeCast.toUint32(weeklyUnlocks[weeksToUnlock]);
         }
-        totalWeeklyWeights[systemWeek] = uint40(getTotalWeightWrite() + totalWeight);
-        totalDecayRate += uint32(totalDecay);
+
+        // update storage total weekly weights and decay rate
+        // using working data totals calculated in previous loops
+        totalWeeklyWeights[systemWeek] = SafeCast.toUint40(getTotalWeightWrite() + totalWeight);
+        totalDecayRate += SafeCast.toUint32(totalDecay);
     }
 
     /** @dev Should not be called directly, use `_addVoteWeights` */
     function _addVoteWeightsFrozen(Vote[] memory votes, uint256 frozenWeight) internal {
+        // get current system week
         uint256 systemWeek = getWeek();
+
+        // working data
         uint256 totalWeight;
+
+        // cache votes length
         uint256 length = votes.length;
+
+        // iterate through every vote
         for (uint256 i; i < length; i++) {
-            uint256 id = votes[i].id;
-            uint256 points = votes[i].points;
+            (uint256 id, uint256 points) = (votes[i].id, votes[i].points);
 
             uint256 weight = (frozenWeight * points) / MAX_POINTS;
 
-            receiverWeeklyWeights[id][systemWeek] = uint40(getReceiverWeightWrite(id) + weight);
+            // trigger receiver weight write to process any missing
+            // weeks until system week, then update storage receiver
+            // weekly weights
+            receiverWeeklyWeights[id][systemWeek] = SafeCast.toUint40(getReceiverWeightWrite(id) + weight);
+
+            // update working data
             totalWeight += weight;
         }
 
-        totalWeeklyWeights[systemWeek] = uint40(getTotalWeightWrite() + totalWeight);
+        // trigger total weight write to process any missing weeks until
+        // system week, then update storage total weekly weights
+        totalWeeklyWeights[systemWeek] = SafeCast.toUint40(getTotalWeightWrite() + totalWeight);
     }
 
     /** @dev Should not be called directly, use `_removeVoteWeights` */
     function _removeVoteWeightsUnfrozen(address account, Vote[] memory votes) internal {
+        // get account locks from TokenLocker
         ITokenLocker.LockData[] memory lockData = _getAccountLocks(account);
+
+        // cache number of locks
         uint256 lockLength = lockData.length;
 
+        // working data
         uint256 totalWeight;
         uint256 totalDecay;
         uint256 systemWeek = getWeek();
         uint256[MAX_LOCK_WEEKS + 1] memory weeklyUnlocks;
 
+        // iterate through every vote
         for (uint256 i; i < votes.length; i++) {
             (uint256 id, uint256 points) = (votes[i].id, votes[i].points);
 
+            // working data
             uint256 weight;
             uint256 decayRate;
+
+            // for every vote, iterate through every lock
             for (uint256 x; x < lockLength; x++) {
                 uint256 weeksToUnlock = lockData[x].weeksToUnlock;
                 uint256 amount = (lockData[x].amount * points) / MAX_POINTS;
-                receiverWeeklyUnlocks[id][systemWeek + weeksToUnlock] -= uint32(amount);
 
-                weeklyUnlocks[weeksToUnlock] += uint32(amount);
+                // updating storage receiver weekly unlocks
+                receiverWeeklyUnlocks[id][systemWeek + weeksToUnlock] -= SafeCast.toUint32(amount);
+
+                // update working data
+                weeklyUnlocks[weeksToUnlock] += SafeCast.toUint32(amount);
                 weight += amount * weeksToUnlock;
                 decayRate += amount;
             }
-            receiverWeeklyWeights[id][systemWeek] = uint40(getReceiverWeightWrite(id) - weight);
-            receiverDecayRate[id] -= uint32(decayRate);
 
+            // update storage receiver weekly weights and decay rate
+            receiverWeeklyWeights[id][systemWeek] = SafeCast.toUint40(getReceiverWeightWrite(id) - weight);
+            receiverDecayRate[id] -= SafeCast.toUint32(decayRate);
+
+            // update working data
             totalWeight += weight;
             totalDecay += decayRate;
         }
 
+        // iterate through every lock updating storage total weekly unlocks
         for (uint256 i; i < lockLength; i++) {
             uint256 weeksToUnlock = lockData[i].weeksToUnlock;
-            totalWeeklyUnlocks[systemWeek + weeksToUnlock] -= uint32(weeklyUnlocks[weeksToUnlock]);
+            totalWeeklyUnlocks[systemWeek + weeksToUnlock]
+                -= SafeCast.toUint32(weeklyUnlocks[weeksToUnlock]);
         }
-        totalWeeklyWeights[systemWeek] = uint40(getTotalWeightWrite() - totalWeight);
-        totalDecayRate -= uint32(totalDecay);
+
+        // update storage total weekly weights and decay rate
+        // using working data totals calculated in previous loops
+        totalWeeklyWeights[systemWeek] = SafeCast.toUint40(getTotalWeightWrite() - totalWeight);
+        totalDecayRate -= SafeCast.toUint32(totalDecay);
     }
 
     /** @dev Should not be called directly, use `_removeVoteWeights` */
     function _removeVoteWeightsFrozen(Vote[] memory votes, uint256 frozenWeight) internal {
+        // get current system week
         uint256 systemWeek = getWeek();
 
+        // working data
         uint256 totalWeight;
+
+        // cache votes length
         uint256 length = votes.length;
+
+        // iterate through every vote
         for (uint256 i; i < length; i++) {
             (uint256 id, uint256 points) = (votes[i].id, votes[i].points);
 
             uint256 weight = (frozenWeight * points) / MAX_POINTS;
 
-            receiverWeeklyWeights[id][systemWeek] = uint40(getReceiverWeightWrite(id) - weight);
+            // trigger receiver weight write to process any missing
+            // weeks until system week, then update storage receiver
+            // weekly weights
+            receiverWeeklyWeights[id][systemWeek] = SafeCast.toUint40(getReceiverWeightWrite(id) - weight);
 
+            // update working data
             totalWeight += weight;
         }
 
-        totalWeeklyWeights[systemWeek] = uint40(getTotalWeightWrite() - totalWeight);
+        // trigger total weight write to process any missing weeks until
+        // system week, then update storage total weekly weights
+        totalWeeklyWeights[systemWeek] = SafeCast.toUint40(getTotalWeightWrite() - totalWeight);
     }
 }

--- a/contracts/dao/TokenLocker.sol
+++ b/contracts/dao/TokenLocker.sol
@@ -34,9 +34,6 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
     IBabelCore public immutable babelCore;
     address public immutable deploymentManager;
 
-    bool public penaltyWithdrawalsEnabled;
-    uint256 public allowPenaltyWithdrawAfter;
-
     struct AccountData {
         // Currently locked balance. Each week the lock weight decays by this amount.
         uint32 locked;
@@ -61,6 +58,9 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
     // Current week within `totalWeeklyWeights` and `totalWeeklyUnlocks`. When up-to-date
     // this value is always equal to `getWeek()`
     uint16 public totalUpdatedWeek;
+
+    bool public penaltyWithdrawalsEnabled;
+    uint256 public allowPenaltyWithdrawAfter;
 
     // week -> total lock weight
     uint40[65535] totalWeeklyWeights;

--- a/contracts/dao/TokenLocker.sol
+++ b/contracts/dao/TokenLocker.sol
@@ -868,6 +868,9 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
         accountWeeklyWeights[msg.sender][systemWeek] = SafeCast.toUint40(locked * MAX_LOCK_WEEKS);
         totalWeeklyWeights[systemWeek] = SafeCast.toUint40(totalWeight - accountWeight + locked * MAX_LOCK_WEEKS);
 
+        // emit event first as locked will be decreased in the while loop
+        emit LocksFrozen(msg.sender, locked);
+
         // use bitfield to iterate acount unlocks and subtract them from the total unlocks
         uint256 bitfield = accountData.updateWeeks[systemWeek / 256] >> (systemWeek % 256);
         while (locked > 0) {
@@ -886,7 +889,6 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
             }
         }
         accountData.updateWeeks[systemWeek / 256] = 0;
-        emit LocksFrozen(msg.sender, locked);
     }
 
     /**

--- a/contracts/dao/TokenLocker.sol
+++ b/contracts/dao/TokenLocker.sol
@@ -419,7 +419,7 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
         uint256 systemWeek = getWeek();
         if (week > systemWeek) return 0;
 
-        // if weekly write has already occured for the input week
+        // if weekly write has already occurred for the input week
         // then just return the weight already calculated
         uint32 updatedWeek = totalUpdatedWeek;
         if (week <= updatedWeek) return totalWeeklyWeights[week];
@@ -431,14 +431,16 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
         weight = totalWeeklyWeights[updatedWeek];
 
         // if no decay return weight from last calculated week
-        // second condition here seems strange
+        // second condition here seems strange and likely to never trigger
         if (rate == 0 || updatedWeek >= systemWeek) {
             return weight;
         }
 
-        // if here weekly write hasn't occurred for passed week(s)
-        // so iterate through and adjust weight for the decay rate
-        while (updatedWeek < systemWeek) {
+        // weekly write hasn't occurred for passed week(s)
+        // so iterate through until the input week adjusting
+        // the output weight for the decay rate and the decay
+        // rate for the weekly unlocks
+        while (updatedWeek < week) {
             updatedWeek++;
             weight -= rate;
             rate -= totalWeeklyUnlocks[updatedWeek];

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -190,7 +190,8 @@ contract BabelVault is IBabelVault, BabelOwnable, SystemStart {
         // notify the receiver contract of the newly registered ID
         // also serves as a sanity check to ensure the contract
         // is capable of receiving emissions
-        IEmissionReceiver(receiver).notifyRegisteredId(assignedIds);
+        require(IEmissionReceiver(receiver).notifyRegisteredId(assignedIds),
+                "notifyRegisteredId must return true");
 
         success = true;
     }

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -593,11 +593,10 @@ contract BabelVault is IBabelVault, BabelOwnable, SystemStart {
             // calculate lock amount accounting for lock to token ratio
             uint256 lockAmount = amount / lockToTokenRatio;
 
-            // @audit is this correct?
-            // amount - lockAmount * lockToTokenRatio
-            // amount - (amount / lockToTokenRatio) * lockToTokenRatio
-            // amount - amount
-            // = 0 ?
+            // the lock amount gets divided by lockToTokenRatio and the lock function
+            // will multiply the input by lockToTokenRatio when transferring tokens, hence
+            // do the same here when updating storage; this sets the pending reward to the
+            // "dust" amount which didn't get locked
             storedPendingReward[claimant] = amount - lockAmount * lockToTokenRatio;
 
             // perform the lock
@@ -734,5 +733,13 @@ contract BabelVault is IBabelVault, BabelOwnable, SystemStart {
 
         // if smaller than lock to token ratio, return 0
         if(amount < lockToTokenRatio) amount = 0;
+    }
+
+    function getAccountWeeklyEarned(address claimant, uint16 week) external view returns (uint128 amount) {
+        amount = accountWeeklyEarned[claimant][week];
+    }
+
+    function getStoredPendingReward(address claimant) external view returns(uint256 amount) {
+        amount = storedPendingReward[claimant];
     }
 }

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -10,7 +10,7 @@ import {IBabelVault, ITokenLocker, IBabelToken, IIncentiveVoting, IEmissionSched
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 interface IEmissionReceiver {
-    function notifyRegisteredId(uint256[] memory assignedIds) external returns (bool);
+    function notifyRegisteredId(uint256[] calldata assignedIds) external returns (bool);
 }
 
 /**

--- a/contracts/dependencies/DelegatedOps.sol
+++ b/contracts/dependencies/DelegatedOps.sol
@@ -18,6 +18,8 @@ import {IDelegatedOps} from "../interfaces/IDelegatedOps.sol";
             minted tokens to the caller.
  */
 contract DelegatedOps is IDelegatedOps {
+    event DelegateApprovalSet(address indexed caller, address indexed delegate, bool isApproved);
+
     mapping(address owner => mapping(address caller => bool isApproved)) public isApprovedDelegate;
 
     modifier callerOrDelegated(address _account) {
@@ -27,5 +29,6 @@ contract DelegatedOps is IDelegatedOps {
 
     function setDelegateApproval(address _delegate, bool _isApproved) external {
         isApprovedDelegate[msg.sender][_delegate] = _isApproved;
+        emit DelegateApprovalSet(msg.sender, _delegate, _isApproved);
     }
 }

--- a/contracts/interfaces/IBorrowerOperations.sol
+++ b/contracts/interfaces/IBorrowerOperations.sol
@@ -21,7 +21,7 @@ interface IBorrowerOperations is IBabelOwnable, IBabelBase, IDelegatedOps {
         uint256[] prices;
     }
 
-    event BorrowingFeePaid(address indexed borrower, uint256 amount);
+    event BorrowingFeePaid(address indexed borrower, IERC20 collateralToken, uint256 amount);
     event CollateralConfigured(ITroveManager, IERC20 collateralToken);
     event TroveCreated(address indexed _borrower, uint256 arrayIndex);
     event TroveManagerRemoved(ITroveManager);

--- a/contracts/interfaces/IEmissionSchedule.sol
+++ b/contracts/interfaces/IEmissionSchedule.sol
@@ -20,7 +20,7 @@ interface IEmissionSchedule is IBabelOwnable, ISystemStart {
     function getTotalWeeklyEmissions(
         uint256 week,
         uint256 unallocatedTotal
-    ) external returns (uint256 amount, uint256 lock);
+    ) external returns (uint256 amount, uint64 lock);
 
     function setLockParameters(uint64 _lockWeeks, uint64 _lockDecayWeeks) external returns (bool);
 

--- a/contracts/interfaces/IIncentiveVoting.sol
+++ b/contracts/interfaces/IIncentiveVoting.sol
@@ -24,7 +24,7 @@ interface IIncentiveVoting is ISystemStart, IDelegatedOps {
 
     function clearVote(address account) external;
 
-    function getReceiverVotePct(uint256 id, uint256 week) external returns (uint256);
+    function getReceiverVoteInputs(uint256 id, uint256 week) external returns (uint256, uint256);
 
     function getReceiverWeightWrite(uint256 idx) external returns (uint256);
 

--- a/contracts/interfaces/ITokenLocker.sol
+++ b/contracts/interfaces/ITokenLocker.sol
@@ -24,6 +24,8 @@ interface ITokenLocker is IBabelOwnable, ISystemStart {
     event LocksFrozen(address indexed account, uint256 amount);
     event LocksUnfrozen(address indexed account, uint256 amount);
     event LocksWithdrawn(address indexed account, uint256 withdrawn, uint256 penalty);
+    event SetAllowPenaltyWithdrawAfter(uint256 startTime);
+    event SetPenaltyWithdrawalsEnabled(bool status);
 
     function extendLock(uint256 _amount, uint256 _weeks, uint256 _newWeeks) external returns (bool);
 

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -47,7 +47,7 @@ interface IBabelVault is IBabelOwnable, ISystemStart {
 
     function setBoostCalculator(IBoostCalculator _boostCalculator) external returns (bool);
 
-    function setBoostDelegationParams(bool isEnabled, uint256 feePct, address callback) external returns (bool);
+    function setBoostDelegationParams(bool isEnabled, uint16 feePct, address callback) external returns (bool);
 
     function setEmissionSchedule(IEmissionSchedule _emissionSchedule) external returns (bool);
 

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -83,7 +83,7 @@ interface IBabelVault is IBabelOwnable, ISystemStart {
 
     function getClaimableWithBoost(address claimant) external view returns (uint256 maxBoosted, uint256 boosted);
 
-    function idToReceiver(uint256) external view returns (address account, bool isActive);
+    function idToReceiver(uint256) external view returns (address account, bool isActive, uint16 updatedWeek);
 
     function lockWeeks() external view returns (uint64);
 
@@ -92,8 +92,6 @@ interface IBabelVault is IBabelOwnable, ISystemStart {
     function claimableBoostDelegationFees(address claimant) external view returns (uint256 amount);
 
     function babelToken() external view returns (IBabelToken);
-
-    function receiverUpdatedWeek(uint256) external view returns (uint16);
 
     function totalUpdateWeek() external view returns (uint64);
 

--- a/contracts/staking/Convex/ConvexDepositToken.sol
+++ b/contracts/staking/Convex/ConvexDepositToken.sol
@@ -112,7 +112,7 @@ contract ConvexDepositToken {
         periodFinish = uint32(block.timestamp - 1);
     }
 
-    function notifyRegisteredId(uint256[] memory assignedIds) external returns (bool) {
+    function notifyRegisteredId(uint256[] calldata assignedIds) external returns (bool) {
         require(msg.sender == address(vault));
         require(emissionId == 0, "Already registered");
         require(assignedIds.length == 1, "Incorrect ID count");

--- a/contracts/staking/Curve/CurveDepositToken.sol
+++ b/contracts/staking/Curve/CurveDepositToken.sol
@@ -72,7 +72,7 @@ contract CurveDepositToken {
         periodFinish = uint32(block.timestamp - 1);
     }
 
-    function notifyRegisteredId(uint256[] memory assignedIds) external returns (bool) {
+    function notifyRegisteredId(uint256[] calldata assignedIds) external returns (bool) {
         require(msg.sender == address(vault));
         require(emissionId == 0, "Already registered");
         require(assignedIds.length == 1, "Incorrect ID count");

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -291,6 +291,11 @@ contract TestSetup is Test {
                                                 INIT_ES_WEEKLY_PCT,
                                                 scheduledWeeklyPct);
 
+        // EmissionSchedule storage correctly set
+        assertEq(emissionSchedule.lockWeeks(), INIT_ES_LOCK_WEEKS);
+        assertEq(emissionSchedule.lockDecayWeeks(), INIT_ES_LOCK_DECAY_WEEKS);
+        assertEq(emissionSchedule.weeklyPct(), INIT_ES_WEEKLY_PCT);
+
         // create BoostCalculator
         boostCalc = new BoostCalculator(address(babelCore),
                                         ITokenLocker(address(tokenLocker)),

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -371,6 +371,23 @@ contract TestSetup is Test {
                                         _fixedInitialAmounts,
                                         initialAllowances);
 
+        // addresses correctly set
+        assertEq(address(babelVault.emissionSchedule()), address(emissionSchedule));
+        assertEq(address(babelVault.boostCalculator()), address(boostCalc));
+
+        // BabelToken supply correct
+        assertEq(babelToken.totalSupply(), INIT_BAB_TKN_TOTAL_SUPPLY);
+        assertEq(babelToken.maxTotalSupply(), INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // BabelToken supply minted to BabelVault
+        assertEq(babelToken.balanceOf(address(babelVault)), INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // BabelVault::totalUpdateWeek correct
+        assertEq(babelVault.totalUpdateWeek(), _fixedInitialAmounts.length + babelVault.getWeek());
+
+        // BabelVault::lockWeeks correct
+        assertEq(babelVault.lockWeeks(), INIT_VLT_LOCK_WEEKS);
+
         // transfer voting tokens to recipients
         vm.prank(users.user1);
         babelToken.transferFrom(address(babelVault), users.user1, user1Allocation);

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -103,7 +103,6 @@ contract TestSetup is Test {
     uint64 internal constant INIT_ES_LOCK_WEEKS = 4;
     uint64 internal constant INIT_ES_LOCK_DECAY_WEEKS = 1;
     uint64 internal constant INIT_ES_WEEKLY_PCT = 2500; // 25%
-    uint64[2][] internal scheduledWeeklyPct;
     uint256 internal constant INIT_BAB_TKN_TOTAL_SUPPLY = type(uint32).max*INIT_LOCK_TO_TOKEN_RATIO;
     uint64 internal constant INIT_VLT_LOCK_WEEKS = 2;
 
@@ -282,6 +281,7 @@ contract TestSetup is Test {
         assertEq(1, factory.troveManagerCount());
 
         // create EmissionSchedule
+        uint64[2][] memory scheduledWeeklyPct;
         emissionSchedule = new EmissionSchedule(address(babelCore), 
                                                 IIncentiveVoting(address(incentiveVoting)),
                                                 IBabelVault(address(babelVault)),

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -310,4 +310,38 @@ contract TestSetup is Test {
         // verify we are in the first week
         assertEq(tokenLocker.getWeek(), 0);
     }
+
+    // common helper functions used in tests
+    function _vaultSetDefaultInitialParameters() internal {
+        uint128[] memory _fixedInitialAmounts;
+        IBabelVault.InitialAllowance[] memory initialAllowances;
+
+        vm.prank(users.owner);
+        babelVault.setInitialParameters(emissionSchedule,
+                                        boostCalc,
+                                        INIT_BAB_TKN_TOTAL_SUPPLY,
+                                        INIT_VLT_LOCK_WEEKS,
+                                        _fixedInitialAmounts,
+                                        initialAllowances);
+
+        // addresses correctly set
+        assertEq(address(babelVault.emissionSchedule()), address(emissionSchedule));
+        assertEq(address(babelVault.boostCalculator()), address(boostCalc));
+
+        // BabelToken supply correct
+        assertEq(babelToken.totalSupply(), INIT_BAB_TKN_TOTAL_SUPPLY);
+        assertEq(babelToken.maxTotalSupply(), INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // BabelToken supply minted to BabelVault
+        assertEq(babelToken.balanceOf(address(babelVault)), INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // BabelVault::unallocatedTotal correct (no initial allowances)
+        assertEq(babelVault.unallocatedTotal(), INIT_BAB_TKN_TOTAL_SUPPLY);
+
+        // BabelVault::totalUpdateWeek correct
+        assertEq(babelVault.totalUpdateWeek(), _fixedInitialAmounts.length + babelVault.getWeek());
+
+        // BabelVault::lockWeeks correct
+        assertEq(babelVault.lockWeeks(), INIT_VLT_LOCK_WEEKS);
+    }
 }

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -359,7 +359,7 @@ contract TestSetup is Test {
         IBabelVault.InitialAllowance[] memory initialAllowances 
             = new IBabelVault.InitialAllowance[](1);
         
-        // give user1 initial allocation of half supply
+        // give user1 initial allocation
         initialAllowances[0].receiver = users.user1;
         initialAllowances[0].amount = user1Allocation;
 
@@ -378,9 +378,9 @@ contract TestSetup is Test {
         // verify recipients have received voting tokens
         assertEq(babelToken.balanceOf(users.user1), user1Allocation);
 
-        // verify half the supply is initially unallocated
+        // verify remaining supply is unallocated
         initialUnallocated = babelVault.unallocatedTotal();
-        assertEq(initialUnallocated, user1Allocation);
+        assertEq(initialUnallocated, INIT_BAB_TKN_TOTAL_SUPPLY - user1Allocation);
 
         // receiver locks up their tokens to get voting weight
         vm.prank(users.user1);

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -94,6 +94,7 @@ contract TestSetup is Test {
     BoostCalculator  internal boostCalc;
 
     // constants
+    uint64 constant internal MAX_PCT = 10000; // 100%
     uint256 internal constant INIT_GAS_COMPENSATION = 200e18;
     uint256 internal constant INIT_MIN_NET_DEBT = 1800e18;
     uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1e18;

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -103,7 +103,7 @@ contract TestSetup is Test {
     uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1e18;
     address internal constant ZERO_ADDRESS = address(0);
 
-    uint256 internal constant INIT_BS_GRACE_WEEKS = 1;
+    uint256 internal constant INIT_BS_GRACE_WEEKS = 2;
     uint64 internal constant INIT_ES_LOCK_WEEKS = 4;
     uint64 internal constant INIT_ES_LOCK_DECAY_WEEKS = 1;
     uint64 internal constant INIT_ES_WEEKLY_PCT = 2500; // 25%

--- a/test/foundry/dao/AllocationVestingTest.t.sol
+++ b/test/foundry/dao/AllocationVestingTest.t.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup, IBabelVault, ITokenLocker} from "../TestSetup.sol";
+import {AllocationVesting} from "./../../../contracts/dao/AllocationVesting.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract AllocationVestingTest is TestSetup {
+    AllocationVesting internal allocationVesting;
+
+    uint256 internal constant totalAllocation = 100_000_000e18;
+    uint256 internal constant maxTotalPreclaimPct = 10;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        allocationVesting = new AllocationVesting(IERC20(address(babelToken)),
+                                                  tokenLocker,
+                                                  totalAllocation,
+                                                  address(babelVault),
+                                                  maxTotalPreclaimPct);
+    }
+
+    function test_transferPoints_failSelfTransfer() external {
+        AllocationVesting.AllocationSplit[] memory allocationSplits
+            = new AllocationVesting.AllocationSplit[](2);
+
+        uint24 INIT_POINTS = 50000;
+
+        // allocate to 2 users 50% 50%
+        allocationSplits[0].recipient = users.user1;
+        allocationSplits[0].points = INIT_POINTS;
+        allocationSplits[0].numberOfWeeks = 4;
+
+        allocationSplits[1].recipient = users.user2;
+        allocationSplits[1].points = INIT_POINTS;
+        allocationSplits[1].numberOfWeeks = 4;
+
+        // setup allocations
+        uint256 vestingStart = block.timestamp + 1 weeks;
+        allocationVesting.setAllocations(allocationSplits, vestingStart);
+
+        // warp to start time
+        vm.warp(vestingStart + 1);
+
+        // reverts on self-transfer exploit which would allow infinite point generation
+        vm.expectRevert(AllocationVesting.SelfTransfer.selector);
+        vm.prank(users.user1);
+        allocationVesting.transferPoints(users.user1, users.user1, INIT_POINTS);
+    }
+}

--- a/test/foundry/dao/AllocationVestingTest.t.sol
+++ b/test/foundry/dao/AllocationVestingTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.19;
 
 // test setup
-import {TestSetup, IBabelVault, ITokenLocker} from "../TestSetup.sol";
+import {TestSetup} from "../TestSetup.sol";
 import {AllocationVesting} from "./../../../contracts/dao/AllocationVesting.sol";
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -16,11 +16,19 @@ contract AllocationVestingTest is TestSetup {
     function setUp() public virtual override {
         super.setUp();
 
+        // first setup the vault
+        _vaultSetDefaultInitialParameters();
+
+        // then create the AllocationVesting contract
         allocationVesting = new AllocationVesting(IERC20(address(babelToken)),
                                                   tokenLocker,
                                                   totalAllocation,
                                                   address(babelVault),
                                                   maxTotalPreclaimPct);
+
+        // BabelVault needs to give max approval to AllocationVesting contract
+        vm.prank(address(babelVault));
+        babelToken.approve(address(allocationVesting), type(uint256).max);
     }
 
     function test_transferPoints_failSelfTransfer() external {
@@ -49,5 +57,75 @@ contract AllocationVestingTest is TestSetup {
         vm.expectRevert(AllocationVesting.SelfTransfer.selector);
         vm.prank(users.user1);
         allocationVesting.transferPoints(users.user1, users.user1, INIT_POINTS);
+    }
+
+    function test_transferPoints_failBypassVestingViaPreclaim() external {
+        AllocationVesting.AllocationSplit[] memory allocationSplits
+            = new AllocationVesting.AllocationSplit[](2);
+
+        uint24 INIT_POINTS = 50000;
+
+        // allocate to 2 users 50% 50%
+        allocationSplits[0].recipient = users.user1;
+        allocationSplits[0].points = INIT_POINTS;
+        allocationSplits[0].numberOfWeeks = 4;
+
+        allocationSplits[1].recipient = users.user2;
+        allocationSplits[1].points = INIT_POINTS;
+        allocationSplits[1].numberOfWeeks = 4;
+
+        // setup allocations
+        uint256 vestingStart = block.timestamp + 1 weeks;
+        allocationVesting.setAllocations(allocationSplits, vestingStart);
+
+        // warp to start time
+        vm.warp(vestingStart + 1);
+
+        // each entity receiving allocations is entitled to 10% preclaim
+        // which they can use to get voting power by locking it up in TokenLocker
+        uint256 MAX_PRECLAIM = (maxTotalPreclaimPct * totalAllocation) / (2 * 100);
+
+        // verify preclaimable amount before claiming
+        assertEq(allocationVesting.preclaimable(users.user1), MAX_PRECLAIM);
+
+        // user1 does this once, passing 0 to preclaim max possible
+        vm.prank(users.user1);
+        allocationVesting.lockFutureClaimsWithReceiver(users.user1, users.user1, 0);
+    
+        // user1 has now preclaimed the max allowed
+        (uint24 points, , , uint96 preclaimed) = allocationVesting.allocations(users.user1);
+        assertEq(preclaimed, MAX_PRECLAIM);
+
+        // verify preclaimable amount now 0
+        assertEq(allocationVesting.preclaimable(users.user1), 0);
+
+        // user1 attempts it again but this fails
+        // as nothing can be claimed
+        vm.expectRevert("Amount must be nonzero");
+        vm.prank(users.user1);
+        allocationVesting.lockFutureClaimsWithReceiver(users.user1, users.user1, 0);
+
+        // user 1 needs to wait 3 days to bypass LockedAllocation revert
+        vm.warp(block.timestamp + 3 days);
+
+        // user1 calls `transferPoints` to move their points to a new address
+        address user1Second = address(0x1337);
+        vm.prank(users.user1);
+        allocationVesting.transferPoints(users.user1, user1Second, INIT_POINTS);
+
+        // but since `transferPoints` transfers preclaimed amounts, the
+        // new address has its preclaimed amounts updated
+        (points, , , preclaimed) = allocationVesting.allocations(user1Second);
+        assertEq(preclaimed, MAX_PRECLAIM);
+        assertEq(points, INIT_POINTS);
+
+        // old address has its preclaimed amounts reduced and also points
+        (points, , , preclaimed) = allocationVesting.allocations(users.user1);
+        assertEq(preclaimed, 0);
+        assertEq(points, 0);
+
+        // both new and old address preclaimable amounts are 0
+        assertEq(allocationVesting.preclaimable(users.user1), 0);
+        assertEq(allocationVesting.preclaimable(user1Second), 0);
     }
 }

--- a/test/foundry/dao/EmissionScheduleTest.t.sol
+++ b/test/foundry/dao/EmissionScheduleTest.t.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup} from "../TestSetup.sol";
+
+contract EmissionScheduleTest is TestSetup {
+
+    function test_setWeeklyPctSchedule() external {
+        // warp forward 5 weeks
+        vm.warp(block.timestamp + 5 weeks);
+        uint256 currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 5);
+
+        // verify no scheduled emissions
+        uint64[2][] memory currentScheduledWeeklyPct = emissionSchedule.getWeeklyPctSchedule();
+        assertEq(currentScheduledWeeklyPct.length, 0);
+
+        // schedule some emissions;
+        // first parameter  : number of weeks from now, must be descending and unique
+        // second parameter : % of unallocated BABEL supply emitted in that week
+        uint64[2][] memory newScheduledWeeklyPct = new uint64[2][](4);
+        newScheduledWeeklyPct[0] = [uint64(4),1];
+        newScheduledWeeklyPct[1] = [uint64(3),1];
+        newScheduledWeeklyPct[2] = [uint64(2),1];
+        newScheduledWeeklyPct[3] = [uint64(1),1];
+
+        vm.prank(users.owner);
+        assertTrue(emissionSchedule.setWeeklyPctSchedule(newScheduledWeeklyPct));
+
+        // verify schedule was correctly saved
+        currentScheduledWeeklyPct = emissionSchedule.getWeeklyPctSchedule();
+        assertEq(currentScheduledWeeklyPct.length, 4);
+
+        for(uint256 i; i<4; i++) {
+            // verify current week was added to input week to get actual week number
+            assertEq(newScheduledWeeklyPct[i][0] + currentWeek, currentScheduledWeeklyPct[i][0]);
+
+            // verify emission percent same as input
+            assertEq(newScheduledWeeklyPct[i][1], currentScheduledWeeklyPct[i][1]);
+        }
+    }
+
+    function test_setWeeklyPctSchedule_sameWeekFails() external {
+        // verify no scheduled emissions
+        uint64[2][] memory curentScheduledWeeklyPct = emissionSchedule.getWeeklyPctSchedule();
+        assertEq(curentScheduledWeeklyPct.length, 0);
+
+        // schedule some emissions;
+        // first parameter  : number of weeks from now, must be descending and unique
+        // second parameter : % of unallocated BABEL supply emitted in that week
+        uint64[2][] memory newScheduledWeeklyPct = new uint64[2][](2);
+        newScheduledWeeklyPct[0] = [uint64(4),1];
+        newScheduledWeeklyPct[1] = [uint64(4),1];
+
+        vm.expectRevert("Must sort by week descending");
+        vm.prank(users.owner);
+        emissionSchedule.setWeeklyPctSchedule(newScheduledWeeklyPct);
+    }
+
+    function test_setWeeklyPctSchedule_ascendingWeekFails() external {
+        // verify no scheduled emissions
+        uint64[2][] memory curentScheduledWeeklyPct = emissionSchedule.getWeeklyPctSchedule();
+        assertEq(curentScheduledWeeklyPct.length, 0);
+
+        // schedule some emissions;
+        // first parameter  : number of weeks from now, must be descending and unique
+        // second parameter : % of unallocated BABEL supply emitted in that week
+        uint64[2][] memory newScheduledWeeklyPct = new uint64[2][](2);
+        newScheduledWeeklyPct[0] = [uint64(4),1];
+        newScheduledWeeklyPct[1] = [uint64(5),1];
+
+        vm.expectRevert("Must sort by week descending");
+        vm.prank(users.owner);
+        emissionSchedule.setWeeklyPctSchedule(newScheduledWeeklyPct);
+    }
+}

--- a/test/foundry/dao/EmissionScheduleTest.t.sol
+++ b/test/foundry/dao/EmissionScheduleTest.t.sol
@@ -6,12 +6,16 @@ import {TestSetup} from "../TestSetup.sol";
 
 contract EmissionScheduleTest is TestSetup {
 
-    function test_setWeeklyPctSchedule() external {
-        // warp forward 5 weeks
-        vm.warp(block.timestamp + 5 weeks);
-        uint256 currentWeek = emissionSchedule.getWeek();
-        assertEq(currentWeek, 5);
-
+    uint64 constant internal EMISSION_10_PCT = 1000;  // 10%
+    
+    // helper function
+    function _setWeeklyPctSchedule(
+        uint256 currentWeek,
+        uint64 emissionPct4,
+        uint64 emissionPct3,
+        uint64 emissionPct2,
+        uint64 emissionPct1
+    ) internal {
         // verify no scheduled emissions
         uint64[2][] memory currentScheduledWeeklyPct = emissionSchedule.getWeeklyPctSchedule();
         assertEq(currentScheduledWeeklyPct.length, 0);
@@ -20,10 +24,10 @@ contract EmissionScheduleTest is TestSetup {
         // first parameter  : number of weeks from now, must be descending and unique
         // second parameter : % of unallocated BABEL supply emitted in that week
         uint64[2][] memory newScheduledWeeklyPct = new uint64[2][](4);
-        newScheduledWeeklyPct[0] = [uint64(4),1];
-        newScheduledWeeklyPct[1] = [uint64(3),1];
-        newScheduledWeeklyPct[2] = [uint64(2),1];
-        newScheduledWeeklyPct[3] = [uint64(1),1];
+        newScheduledWeeklyPct[0] = [uint64(4), emissionPct4];
+        newScheduledWeeklyPct[1] = [uint64(3), emissionPct3];
+        newScheduledWeeklyPct[2] = [uint64(2), emissionPct2];
+        newScheduledWeeklyPct[3] = [uint64(1), emissionPct1];
 
         vm.prank(users.owner);
         assertTrue(emissionSchedule.setWeeklyPctSchedule(newScheduledWeeklyPct));
@@ -39,6 +43,26 @@ contract EmissionScheduleTest is TestSetup {
             // verify emission percent same as input
             assertEq(newScheduledWeeklyPct[i][1], currentScheduledWeeklyPct[i][1]);
         }
+    }
+
+    function test_setWeeklyPctSchedule(
+        uint64 emissionPct4,
+        uint64 emissionPct3,
+        uint64 emissionPct2,
+        uint64 emissionPct1
+    ) external {
+        // bound inputs
+        emissionPct4 = uint64(bound(emissionPct4, 0, MAX_PCT));
+        emissionPct3 = uint64(bound(emissionPct3, 0, MAX_PCT));
+        emissionPct2 = uint64(bound(emissionPct2, 0, MAX_PCT));
+        emissionPct1 = uint64(bound(emissionPct1, 0, MAX_PCT));
+
+        // warp forward 5 weeks
+        vm.warp(block.timestamp + 5 weeks);
+        uint256 currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 5);
+
+        _setWeeklyPctSchedule(currentWeek, emissionPct4, emissionPct3, emissionPct2, emissionPct1);
     }
 
     function test_setWeeklyPctSchedule_sameWeekFails() external {
@@ -74,4 +98,135 @@ contract EmissionScheduleTest is TestSetup {
         vm.prank(users.owner);
         emissionSchedule.setWeeklyPctSchedule(newScheduledWeeklyPct);
     }
+
+    function test_getTotalWeeklyEmissions_onlyVault() external {
+        vm.expectRevert();
+        emissionSchedule.getTotalWeeklyEmissions(0,0);
+    }
+
+    function test_getTotalWeeklyEmissions(
+        uint256 unallocatedTotal,
+        uint64 emissionPct4,
+        uint64 emissionPct3,
+        uint64 emissionPct2,
+        uint64 emissionPct1
+    ) external {
+        // bound inputs
+        unallocatedTotal = bound(unallocatedTotal, 0, type(uint128).max);
+        emissionPct4 = uint64(bound(emissionPct4, 0, MAX_PCT));
+        emissionPct3 = uint64(bound(emissionPct3, 0, MAX_PCT));
+        emissionPct2 = uint64(bound(emissionPct2, 0, MAX_PCT));
+        emissionPct1 = uint64(bound(emissionPct1, 0, MAX_PCT));
+
+        // warp forward 5 weeks
+        vm.warp(block.timestamp + 5 weeks);
+        uint256 currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 5);
+
+        _setWeeklyPctSchedule(currentWeek, emissionPct4, emissionPct3, emissionPct2, emissionPct1);
+
+        // warp to first week of schedule
+        vm.warp(block.timestamp + 1 weeks);
+        currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 6);
+
+        uint256 savedLockWeeks = emissionSchedule.lockWeeks();
+
+        vm.prank(address(babelVault));
+        (uint256 amount, uint256 lock) 
+            = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
+
+        assertEq(amount, unallocatedTotal * emissionPct1 / MAX_PCT);
+
+        // lockWeeks reduced by 1 and storage updated
+        assertEq(lock, savedLockWeeks - 1);
+        assertEq(lock, emissionSchedule.lockWeeks());
+
+        // weeklyPct updated
+        assertEq(emissionPct1, emissionSchedule.weeklyPct());
+
+        // one schedule update removed
+        assertEq(emissionSchedule.getWeeklyPctSchedule().length, 3);
+
+        // warp to second week of schedule
+        vm.warp(block.timestamp + 1 weeks);
+        currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 7);
+
+        vm.prank(address(babelVault));
+        (amount, lock) 
+            = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
+
+        assertEq(amount, unallocatedTotal * emissionPct2 / MAX_PCT);
+
+        // lockWeeks reduced by 2 and storage updated
+        assertEq(lock, savedLockWeeks - 2);
+        assertEq(lock, emissionSchedule.lockWeeks());
+
+        // weeklyPct updated
+        assertEq(emissionPct2, emissionSchedule.weeklyPct());
+
+        // two schedule updates removed
+        assertEq(emissionSchedule.getWeeklyPctSchedule().length, 2);
+
+        // warp to third week of schedule
+        vm.warp(block.timestamp + 1 weeks);
+        currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 8);
+
+        vm.prank(address(babelVault));
+        (amount, lock) 
+            = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
+
+        assertEq(amount, unallocatedTotal * emissionPct3 / MAX_PCT);
+
+        // lockWeeks reduced by 3 and storage updated
+        assertEq(lock, savedLockWeeks - 3);
+        assertEq(lock, emissionSchedule.lockWeeks());
+
+        // weeklyPct updated
+        assertEq(emissionPct3, emissionSchedule.weeklyPct());
+
+        // three schedule updates removed
+        assertEq(emissionSchedule.getWeeklyPctSchedule().length, 1);
+
+        // warp to fourth week of schedule
+        vm.warp(block.timestamp + 1 weeks);
+        currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 9);
+
+        vm.prank(address(babelVault));
+        (amount, lock) 
+            = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
+
+        assertEq(amount, unallocatedTotal * emissionPct4 / MAX_PCT);
+
+        // lockWeeks reduced by 4 and storage updated
+        assertEq(lock, savedLockWeeks - 4);
+        assertEq(lock, emissionSchedule.lockWeeks());
+
+        // weeklyPct updated
+        assertEq(emissionPct4, emissionSchedule.weeklyPct());
+
+        // four schedule updates removed
+        assertEq(emissionSchedule.getWeeklyPctSchedule().length, 0);
+
+        // warp one week forward after schedule
+        vm.warp(block.timestamp + 1 weeks);
+        currentWeek = emissionSchedule.getWeek();
+        assertEq(currentWeek, 10);
+
+        vm.prank(address(babelVault));
+        (amount, lock) 
+            = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
+
+        // confirm it is using values from last week of schedule
+        // since that was the last modification
+        assertEq(amount, unallocatedTotal * emissionPct4 / MAX_PCT);
+        assertEq(lock, savedLockWeeks - 4);
+        assertEq(lock, emissionSchedule.lockWeeks());
+        assertEq(emissionPct4, emissionSchedule.weeklyPct());
+        assertEq(emissionSchedule.getWeeklyPctSchedule().length, 0);
+    }
+
 }

--- a/test/foundry/dao/TokenLockerTest.t.sol
+++ b/test/foundry/dao/TokenLockerTest.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.19;
 // test setup
 import {TestSetup, IBabelVault, ITokenLocker} from "../TestSetup.sol";
 
+import {console} from "forge-std/console.sol";
+
 contract TokenLockerTest is TestSetup {
 
     function setUp() public virtual override {
@@ -34,33 +36,27 @@ contract TokenLockerTest is TestSetup {
         assertEq(babelToken.balanceOf(users.user1), INIT_BAB_TKN_TOTAL_SUPPLY);
     }
 
-    function test_lock(uint256 amountToLock, uint256 weeksToLockFor) public
+    // helper function
+    function _lock(uint256 amountToLock, uint256 weeksToLockFor) internal
         returns(uint256 lockedAmount, uint256 weeksLockedFor) 
     {
         // save user initial balance
-        uint256 userInitialBalance = babelToken.balanceOf(users.user1);
-        assertEq(userInitialBalance, INIT_BAB_TKN_TOTAL_SUPPLY);
+        uint256 userPreLockTokedBalance = babelToken.balanceOf(users.user1);
 
-        // bound fuzz inputs
-        // need to divide by lockToTokenRatio when calling the
-        // lock function since the token transfer multiplies by lockToTokenRatio
-        lockedAmount = bound(amountToLock, 1, userInitialBalance/INIT_LOCK_TO_TOKEN_RATIO);
-        weeksLockedFor = bound(weeksToLockFor, 1, tokenLocker.MAX_LOCK_WEEKS());
+        (uint256 userPreLockLockedBalance, ) = tokenLocker.getAccountBalances(users.user1);
 
-        // verify user has no voting weight
-        assertEq(tokenLocker.getAccountWeight(users.user1), 0);
-
-        // lock up random amount for random weeks
+        // lock up specified amount for specified weeks
         vm.prank(users.user1);
-        tokenLocker.lock(users.user1, lockedAmount, weeksLockedFor);
+        tokenLocker.lock(users.user1, amountToLock, weeksToLockFor);
 
         // verify locked amount is correct
-        (uint256 locked, uint256 unlocked) = tokenLocker.getAccountBalances(users.user1);
-        assertEq(locked, lockedAmount);
-        assertEq(unlocked, 0);
+        (lockedAmount, ) = tokenLocker.getAccountBalances(users.user1);
+        lockedAmount -= userPreLockLockedBalance;
+
+        assertEq(lockedAmount, amountToLock);
         // when checking actual token balances, need to multipy lockedAmount by
         // lockToTokenRatio since the token transfer multiplies by lockToTokenRatio
-        assertEq(babelToken.balanceOf(users.user1), userInitialBalance - lockedAmount*INIT_LOCK_TO_TOKEN_RATIO);
+        assertEq(babelToken.balanceOf(users.user1), userPreLockTokedBalance - lockedAmount*INIT_LOCK_TO_TOKEN_RATIO);
 
         // verify user has positive voting weight in the current week
         uint256 userWeight = tokenLocker.getAccountWeight(users.user1);
@@ -86,7 +82,24 @@ contract TokenLockerTest is TestSetup {
         // this behavior is weird and not sure if it is correct;
         // if user locks for   1 week, activeLockData[0].weeksToUnlock == weeksToLockFor + 1 == 2
         // if user locks for > 1 week, activeLockData[0].weeksToUnlock == weeksToLockFor
-        assertEq(activeLockData[0].weeksToUnlock, weeksLockedFor == 1 ? 2 : weeksLockedFor);
+        assertEq(activeLockData[0].weeksToUnlock, weeksToLockFor == 1 ? 2 : weeksToLockFor);
+
+        weeksLockedFor = activeLockData[0].weeksToUnlock;
+    }
+
+    function test_lock(uint256 amountToLock, uint256 weeksToLockFor) public
+        returns(uint256, uint256) 
+    {
+        // bound fuzz inputs
+        // need to divide by lockToTokenRatio when calling the
+        // lock function since the token transfer multiplies by lockToTokenRatio
+        amountToLock = bound(amountToLock, 1, babelToken.balanceOf(users.user1)/INIT_LOCK_TO_TOKEN_RATIO);
+
+        // using -1 week since withdrawing early penalties doesn't reach to tokens
+        // locked in the last week
+        weeksToLockFor = bound(weeksToLockFor, 1, tokenLocker.MAX_LOCK_WEEKS() - 1);
+
+        return _lock(amountToLock, weeksToLockFor);
     }
 
     function test_lock_immediate_withdraw(uint256 amountToLock, uint256 weeksToLockFor, uint256 relockFor) external {
@@ -185,5 +198,142 @@ contract TokenLockerTest is TestSetup {
             // if user locks for > 1 week, activeLockData[0].weeksToUnlock == weeksToLockFor
             assertEq(activeLockData[0].weeksToUnlock, relockFor == 1 ? 2 : relockFor);
         }
+    }
+
+    // returns a valid penalty start time
+    function _getPenaltyStartTime(uint256 rand) internal view returns(uint256 startTime) {
+        startTime = bound(rand, block.timestamp + 1, block.timestamp + 13 weeks - 1);
+    }
+
+    function test_setAllowPenaltyWithdrawAfter(uint256 startTime) public {
+        // bound inputs
+        startTime = _getPenaltyStartTime(startTime);
+
+        vm.prank(users.owner);
+        assertTrue(tokenLocker.setAllowPenaltyWithdrawAfter(startTime));
+
+        assertEq(tokenLocker.allowPenaltyWithdrawAfter(), startTime);
+    }
+
+    function test_setAllowPenaltyWithdraw_onlyDeployer() external {
+        vm.expectRevert("!deploymentManager");
+        tokenLocker.setAllowPenaltyWithdrawAfter(0);
+    }
+
+    function test_setAllowPenaltyWithdraw_onlyOnce(uint256 startTime) external {
+        // bound inputs
+        startTime = _getPenaltyStartTime(startTime);
+
+        // once works
+        test_setAllowPenaltyWithdrawAfter(startTime);
+
+        // twice fails
+        vm.expectRevert("Already set");
+        vm.prank(users.owner);
+        tokenLocker.setAllowPenaltyWithdrawAfter(startTime);
+    }
+
+    function test_setAllowPenaltyWithdraw_invalidStartTime(uint256 startTime) external {
+        // too early fails
+        startTime = bound(startTime, 0, block.timestamp);
+
+        vm.expectRevert("Invalid timestamp");
+        vm.prank(users.owner);
+        tokenLocker.setAllowPenaltyWithdrawAfter(startTime);
+
+        // too late fails
+        startTime = bound(startTime, block.timestamp + 13 weeks, type(uint128).max);
+
+        vm.expectRevert("Invalid timestamp");
+        vm.prank(users.owner);
+        tokenLocker.setAllowPenaltyWithdrawAfter(startTime);
+    }
+
+    function test_setPenaltyWithdrawalsEnabled(uint256 startTime, bool status) public {
+        // first set the start time
+        test_setAllowPenaltyWithdrawAfter(startTime);
+
+        // warp past it
+        vm.warp(tokenLocker.allowPenaltyWithdrawAfter() + 1);
+
+        // then toggle the enabled flag
+        vm.prank(users.owner);
+        tokenLocker.setPenaltyWithdrawalsEnabled(status);
+
+        assertEq(tokenLocker.penaltyWithdrawalsEnabled(), status);
+    }
+    
+    function test_setPenaltyWithdrawalsEnabled_onlyOwner() external {
+        vm.expectRevert("Only owner");
+        tokenLocker.setPenaltyWithdrawalsEnabled(true);
+    }
+
+    function test_setPenaltyWithdrawalsEnabled_beforeStartTime(uint256 startTime, bool status) external {
+        // first set the start time
+        test_setAllowPenaltyWithdrawAfter(startTime);
+
+        // then immediately attempt setting the flag
+        vm.expectRevert("Not yet!");
+        vm.prank(users.owner);
+        tokenLocker.setPenaltyWithdrawalsEnabled(status);
+    }
+
+    function test_withdrawWithPenalty_notEnabled() external {
+        vm.expectRevert("Penalty withdrawals are disabled");
+        tokenLocker.withdrawWithPenalty(0);
+    }
+
+    function test_withdrawWithPenalty_failOnZero() external {
+        // first enable penalty withdrawals
+        test_setPenaltyWithdrawalsEnabled(0, true);
+
+        // fail when attempting zero input
+        vm.expectRevert("Must withdraw a positive amount");
+        vm.prank(users.user1);
+        tokenLocker.withdrawWithPenalty(0);
+
+        // fail when attempting zero input
+        vm.expectRevert("Must withdraw a positive amount");
+        vm.prank(users.user1);
+        tokenLocker.withdrawWithPenalty(type(uint256).max);
+    }
+
+    function test_withdrawWithPenalty(uint256 amountToLock, uint256 weeksToLockFor) external {
+        // first enable penalty withdrawals
+        test_setPenaltyWithdrawalsEnabled(0, true);
+
+        // save user initial balance
+        uint256 userPreTokenBalance = babelToken.balanceOf(users.user1);
+
+        // perform the lock
+        (uint256 lockedAmount, uint256 weeksLockedFor) = test_lock(amountToLock, weeksToLockFor);
+
+        uint256 week = tokenLocker.getWeek();
+
+        // verify user has received weight in the current week
+        uint256 accountWeightPreWithdraw = tokenLocker.getAccountWeightAt(users.user1, week);
+        assertTrue(accountWeightPreWithdraw != 0);
+
+        // verify total weight for current week all belongs to user
+        assertEq(tokenLocker.getTotalWeight(), accountWeightPreWithdraw);
+
+        // perform the withdraw with penalty
+        vm.prank(users.user1);
+        tokenLocker.withdrawWithPenalty(type(uint256).max);
+
+        // calculate expected penalty
+        uint256 penaltyOnAmount = (lockedAmount * INIT_LOCK_TO_TOKEN_RATIO * weeksLockedFor) / tokenLocker.MAX_LOCK_WEEKS();
+
+        // verify feeReceiver receives expected penalty
+        assertEq(babelToken.balanceOf(address(babelCore.feeReceiver())), penaltyOnAmount);
+
+        // verify user has received their tokens minus the penalty
+        assertEq(babelToken.balanceOf(users.user1), userPreTokenBalance - penaltyOnAmount);
+
+        // verify account's weight was reset
+        assertEq(tokenLocker.getAccountWeightAt(users.user1, week), 0);
+
+        // verify total weight was reset
+        assertEq(tokenLocker.getTotalWeight(), 0);
     }
 }

--- a/test/foundry/dao/TokenLockerTest.t.sol
+++ b/test/foundry/dao/TokenLockerTest.t.sol
@@ -41,7 +41,7 @@ contract TokenLockerTest is TestSetup {
         returns(uint256 lockedAmount, uint256 weeksLockedFor) 
     {
         // save user initial balance
-        uint256 userPreLockTokedBalance = babelToken.balanceOf(users.user1);
+        uint256 userPreLockTokenBalance = babelToken.balanceOf(users.user1);
 
         (uint256 userPreLockLockedBalance, ) = tokenLocker.getAccountBalances(users.user1);
 
@@ -56,7 +56,7 @@ contract TokenLockerTest is TestSetup {
         assertEq(lockedAmount, amountToLock);
         // when checking actual token balances, need to multipy lockedAmount by
         // lockToTokenRatio since the token transfer multiplies by lockToTokenRatio
-        assertEq(babelToken.balanceOf(users.user1), userPreLockTokedBalance - lockedAmount*INIT_LOCK_TO_TOKEN_RATIO);
+        assertEq(babelToken.balanceOf(users.user1), userPreLockTokenBalance - lockedAmount*INIT_LOCK_TO_TOKEN_RATIO);
 
         // verify user has positive voting weight in the current week
         uint256 userWeight = tokenLocker.getAccountWeight(users.user1);

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -4,7 +4,34 @@ pragma solidity 0.8.19;
 // test setup
 import {TestSetup, IBabelVault, BabelVault, IIncentiveVoting, ITokenLocker} from "../TestSetup.sol";
 
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract MockEmissionReceiver {
+    bool public notifyRegisteredIdCalled;
+    uint256[] public lastAssignedIds;
+
+    function notifyRegisteredId(uint256[] memory assignedIds) external returns (bool) {
+        notifyRegisteredIdCalled = true;
+        lastAssignedIds = assignedIds;
+        return true;
+    }
+
+    /**
+     * @notice Asserts that notifyRegisteredId was called with the expected number of assigned IDs
+     * @dev Added this for testing purposes
+     * @param expectedCount The expected number of assigned IDs
+     */
+    function assertNotifyRegisteredIdCalled(uint256 expectedCount) external view {
+        require(notifyRegisteredIdCalled, "notifyRegisteredId was not called");
+        require(lastAssignedIds.length == expectedCount, "Unexpected number of assigned IDs");
+    }
+}
+
+
 contract VaultTest is TestSetup {
+
+    uint256 constant internal MAX_COUNT = 10;
     
     function test_constructor() external view {
         // addresses correctly set
@@ -15,45 +42,179 @@ contract VaultTest is TestSetup {
         assertEq(babelVault.lockToTokenRatio(), INIT_LOCK_TO_TOKEN_RATIO);
 
         // StabilityPool made receiver with ID 0
-        (address account, bool isActive) = babelVault.idToReceiver(0);        
+        (address account, bool isActive, uint16 updatedWeek) = babelVault.idToReceiver(0);        
         assertEq(account, address(stabilityPool));
         assertEq(isActive, true);
+        assertEq(updatedWeek, 0);
 
         // IncentiveVoting receiver count was increased by 1
         assertEq(incentiveVoting.receiverCount(), 1);
     }
 
     function test_setInitialParameters() public {
-        uint128[] memory _fixedInitialAmounts;
-        IBabelVault.InitialAllowance[] memory initialAllowances;
+        _vaultSetDefaultInitialParameters();
+    }
+
+    function test_transferTokens(address receiver, uint256 amount) public {
+        // bound fuzz inputs
+        vm.assume(receiver != address(0) &&
+                  receiver != address(babelVault) &&
+                  receiver != address(babelToken));
+
+        amount = bound(amount, 0, babelToken.balanceOf(address(babelVault)));
+
+        // save previous state
+        uint256 initialUnallocated = babelVault.unallocatedTotal();
+        uint256 initialBabelBalance = babelToken.balanceOf(address(babelVault));
+        uint256 initialReceiverBalance = babelToken.balanceOf(receiver);
 
         vm.prank(users.owner);
-        babelVault.setInitialParameters(emissionSchedule,
-                                        boostCalc,
-                                        INIT_BAB_TKN_TOTAL_SUPPLY,
-                                        INIT_VLT_LOCK_WEEKS,
-                                        _fixedInitialAmounts,
-                                        initialAllowances);
+        assertTrue(babelVault.transferTokens(IERC20(address(babelToken)), receiver, amount));
+        assertEq(babelVault.unallocatedTotal(), initialUnallocated - amount);
+        assertEq(babelToken.balanceOf(address(babelVault)), initialBabelBalance - amount);
+        assertEq(babelToken.balanceOf(receiver), initialReceiverBalance + amount);
 
-        // addresses correctly set
-        assertEq(address(babelVault.emissionSchedule()), address(emissionSchedule));
-        assertEq(address(babelVault.boostCalculator()), address(boostCalc));
+        // test with non-BabelToken
+        IERC20 mockToken = new ERC20("Mock", "MCK");
+        uint256 mockAmount = 1000 * 10 ** 18;
+        deal(address(mockToken), address(babelVault), mockAmount);
 
-        // BabelToken supply correct
-        assertEq(babelToken.totalSupply(), INIT_BAB_TKN_TOTAL_SUPPLY);
-        assertEq(babelToken.maxTotalSupply(), INIT_BAB_TKN_TOTAL_SUPPLY);
+        uint256 initialMockBalance = mockToken.balanceOf(address(babelVault));
+        uint256 initialReceiverMockBalance = mockToken.balanceOf(receiver);
 
-        // BabelToken supply minted to BabelVault
-        assertEq(babelToken.balanceOf(address(babelVault)), INIT_BAB_TKN_TOTAL_SUPPLY);
+        vm.prank(users.owner);
+        assertTrue(babelVault.transferTokens(mockToken, receiver, mockAmount));
 
-        // BabelVault::unallocatedTotal correct (no initial allowances)
-        assertEq(babelVault.unallocatedTotal(), INIT_BAB_TKN_TOTAL_SUPPLY);
-
-        // BabelVault::totalUpdateWeek correct
-        assertEq(babelVault.totalUpdateWeek(), _fixedInitialAmounts.length + babelVault.getWeek());
-
-        // BabelVault::lockWeeks correct
-        assertEq(babelVault.lockWeeks(), INIT_VLT_LOCK_WEEKS);
-
+        assertEq(babelVault.unallocatedTotal(), initialUnallocated - amount); // Unchanged
+        assertEq(mockToken.balanceOf(address(babelVault)), initialMockBalance - mockAmount);
+        assertEq(mockToken.balanceOf(receiver), initialReceiverMockBalance + mockAmount);
     }
+
+    function test_transferTokens_revert(address receiver, uint256 amount) public {
+        // bound fuzz inputs
+        vm.assume(receiver != address(0));
+        amount = bound(amount, 0, babelToken.balanceOf(address(babelVault)));
+
+        // Test revert on non-owner call
+        vm.prank(users.user1);
+        vm.expectRevert("Only owner");
+        babelVault.transferTokens(IERC20(address(babelToken)), receiver, amount);
+
+        // Test revert on self-transfer
+        vm.prank(users.owner);
+        vm.expectRevert("Self transfer denied");
+        babelVault.transferTokens(IERC20(address(babelToken)), address(babelVault), amount);
+
+        // Test revert on insufficient balance
+        uint256 excessiveAmount = babelToken.balanceOf(address(babelVault)) + 1;
+        vm.prank(users.owner);
+        vm.expectRevert();
+        babelVault.transferTokens(IERC20(address(babelToken)), receiver, excessiveAmount);
+    }
+
+    /* todo - failing with out of gas
+    function test_registerReceiver(address receiver, uint256 count, uint256 weeksToAdd) public {
+        // bound fuzz inputs
+        vm.assume(receiver != address(0) && receiver != address(babelVault));
+        vm.assume(uint160(receiver) > 9); // Exclude precompile addresses (0x1 to 0x9)
+        count = bound(count, 1, MAX_COUNT); // Limit count to avoid excessive gas usage or memory issues
+        weeksToAdd = bound(weeksToAdd, 0, type(uint64).max - 1);
+        vm.assume(weeksToAdd <= type(uint64).max - 1);
+
+        // Set up week
+        vm.warp(block.timestamp + weeksToAdd * 1 weeks);
+        uint256 currentWeek = babelVault.getWeek();
+
+        // Mock the IEmissionReceiver interface
+        MockEmissionReceiver mockReceiver = new MockEmissionReceiver();
+        vm.etch(receiver, address(mockReceiver).code);
+
+        // Have owner register receiver
+        vm.prank(users.owner);
+        assertTrue(babelVault.registerReceiver(receiver, count));
+
+        for (uint256 i = 1; i <= count; i++) {
+            (address registeredReceiver, bool isActive) = babelVault.idToReceiver(i);
+            assertEq(registeredReceiver, receiver);
+            assertTrue(isActive);
+            assertEq(babelVault.receiverUpdatedWeek(i), uint16(currentWeek));
+        }
+
+        // Verify IncentiveVoting state
+        assertEq(incentiveVoting.receiverCount(), count + 1); // +1 because of the initial StabilityPool receiver
+
+        // Verify MockEmissionReceiver state
+        MockEmissionReceiver(receiver).assertNotifyRegisteredIdCalled(count);
+    }
+    */
+
+    function test_registerReceiver_zeroCount() public {
+        vm.prank(users.owner);
+        vm.expectRevert();
+        babelVault.registerReceiver(address(1), 0);
+    }
+
+    function test_registerReceiver_revert_zeroAddress() public {
+        vm.prank(users.owner);
+        vm.expectRevert();
+        babelVault.registerReceiver(address(0), 1);
+    }
+
+    function test_registerReceiver_revert_babelVault() public {
+        vm.prank(users.owner);
+        vm.expectRevert();
+        babelVault.registerReceiver(address(babelVault), 1);
+    }
+
+    function test_registerReceiver_revert_nonOwner() public {
+        vm.prank(users.user1);
+        vm.expectRevert();
+        babelVault.registerReceiver(address(1), 1);
+    }
+
+    /* todo
+    function test_allocateNewEmissions(address receiver, uint256 count, uint256 weeksToAdd) public {
+        // bound fuzz inputs
+        vm.assume(receiver != address(0) && receiver != address(babelVault));
+        vm.assume(uint160(receiver) > 9); // Exclude precompile addresses (0x1 to 0x9)
+        count = bound(count, 1, 100); // Limit count to avoid excessive gas usage or memory issues
+        weeksToAdd = bound(weeksToAdd, 0, type(uint64).max - 1);
+        vm.assume(weeksToAdd <= type(uint64).max - 1);
+
+        // Set up week
+        vm.warp(block.timestamp + weeksToAdd * 1 weeks);
+
+        // Mock the IEmissionReceiver interface
+        MockEmissionReceiver mockReceiver = new MockEmissionReceiver();
+        vm.etch(receiver, address(mockReceiver).code);
+
+        // Have owner register receiver
+        vm.prank(users.owner);
+        assertTrue(babelVault.registerReceiver(receiver, count));
+
+        // Simulate time passing some more
+        vm.warp(block.timestamp + weeksToAdd * 1 weeks);
+
+        uint256 initialUnallocated = babelVault.unallocatedTotal();
+
+        // Call allocateNewEmissions
+        uint256 id = 1;
+        vm.prank(receiver);
+        uint256 allocated = babelVault.allocateNewEmissions(id);
+
+        // Calculate expected unallocated total
+        uint256 expectedUnallocated = initialUnallocated;
+        (, bool isActive) = babelVault.idToReceiver(id);
+        if (!isActive) {
+            // If receiver is inactive, unallocated total should remain the same as after _allocateTotalWeekly
+            expectedUnallocated = babelVault.unallocatedTotal();
+        }
+
+        // Assertions
+        assertEq(babelVault.unallocatedTotal(), expectedUnallocated, "Unallocated total not updated correctly");
+        assertEq(allocated, 0, "Incorrect amount allocated");
+        assertEq(babelVault.allocated(receiver), 0, "Allocated amount should be 0 for inactive receiver");
+        //assertEq(babelVault.receiverUpdatedWeek(id), babelVault.getWeek(), "Receiver week not updated correctly");
+    }
+    */
 }

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -256,7 +256,16 @@ contract VaultTest is TestSetup {
         assertEq(updatedWeek, systemWeek);
 
         // verify receiver was allocated the first week's emissions   
-        assertEq(allocated, firstWeekEmissions);        
+        assertEq(allocated, firstWeekEmissions);
+        assertEq(babelVault.allocated(receiver), firstWeekEmissions);
+
+        // receiver calls allocateNewEmissions again
+        vm.prank(receiver);
+        uint256 allocated2 = babelVault.allocateNewEmissions(RECEIVER_ID);
+
+        // doesn't return any more since already been called for current system week
+        assertEq(allocated2, 0);
+        assertEq(babelVault.allocated(receiver), firstWeekEmissions);
     }
 
     function test_allocateNewEmissions_twoReceiversWithEqualVotingWeight() external {
@@ -317,6 +326,7 @@ contract VaultTest is TestSetup {
 
         // verify receiver was allocated half of first week's emissions   
         assertEq(allocated, firstWeekEmissions/2);
+        assertEq(babelVault.allocated(receiver), firstWeekEmissions/2);
 
         // receiver2 calls allocateNewEmissions
         vm.prank(receiver2);
@@ -335,6 +345,7 @@ contract VaultTest is TestSetup {
 
         // verify receiver2 was allocated half of first week's emissions   
         assertEq(allocated, firstWeekEmissions/2);
+        assertEq(babelVault.allocated(receiver2), firstWeekEmissions/2);
     }
 
     function test_allocateNewEmissions_twoReceiversWithUnequalExtremeVotingWeight() external {
@@ -416,7 +427,9 @@ contract VaultTest is TestSetup {
         assertEq(allocated + allocated2, 536870911874999999999999999);
 
         assertEq(allocated,  53687000037499936332460);
+        assertEq(babelVault.allocated(receiver), 53687000037499936332460);
         assertEq(allocated2, 536817224874962500063667539);
+        assertEq(babelVault.allocated(receiver2), 536817224874962500063667539);
     }
 
 }

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -259,7 +259,7 @@ contract VaultTest is TestSetup {
         assertEq(allocated, firstWeekEmissions);        
     }
 
-    function test_allocateNewEmissions_twoReceiversWithVotingWeight() public {
+    function test_allocateNewEmissions_twoReceiversWithEqualVotingWeight() public {
         // setup vault giving user1 half supply to lock for voting power
         uint256 initialUnallocated = _vaultSetupAndLockTokens(INIT_BAB_TKN_TOTAL_SUPPLY/2);
 

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -11,10 +11,10 @@ contract MockEmissionReceiver {
     bool public notifyRegisteredIdCalled;
     uint256[] public lastAssignedIds;
 
-    function notifyRegisteredId(uint256[] memory assignedIds) external returns (bool) {
+    function notifyRegisteredId(uint256[] calldata assignedIds) external returns (bool success) {
         notifyRegisteredIdCalled = true;
         lastAssignedIds = assignedIds;
-        return true;
+        success = true;
     }
 
     /**

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -65,7 +65,10 @@ contract VaultTest is TestSetup {
         _vaultSetDefaultInitialParameters();
     }
 
-    function test_transferTokens(address receiver, uint256 amount) public {
+    function test_transferTokens(address receiver, uint256 amount) external {
+        // first need to fund vault with tokens
+        test_setInitialParameters();
+
         // bound fuzz inputs
         vm.assume(receiver != address(0) &&
                   receiver != address(babelVault) &&
@@ -100,7 +103,10 @@ contract VaultTest is TestSetup {
         assertEq(mockToken.balanceOf(receiver), initialReceiverMockBalance + mockAmount);
     }
 
-    function test_transferTokens_revert(address receiver, uint256 amount) public {
+    function test_transferTokens_revert(address receiver, uint256 amount) external {
+        // first need to fund vault with tokens
+        test_setInitialParameters();
+
         // bound fuzz inputs
         vm.assume(receiver != address(0));
         amount = bound(amount, 0, babelToken.balanceOf(address(babelVault)));
@@ -122,7 +128,7 @@ contract VaultTest is TestSetup {
         babelVault.transferTokens(IERC20(address(babelToken)), receiver, excessiveAmount);
     }
 
-    function test_registerReceiver(uint256 count, uint256 weeksToAdd) public {
+    function test_registerReceiver(uint256 count, uint256 weeksToAdd) external {
         // bound fuzz inputs
         count = bound(count, 1, MAX_COUNT); // Limit count to avoid excessive gas usage or memory issues
         weeksToAdd = bound(weeksToAdd, 0, MAX_COUNT);
@@ -152,31 +158,35 @@ contract VaultTest is TestSetup {
         mockEmissionReceiver.assertNotifyRegisteredIdCalled(count);
     }
 
-    function test_registerReceiver_zeroCount() public {
+    function test_registerReceiver_zeroCount() external {
         vm.prank(users.owner);
         vm.expectRevert();
         babelVault.registerReceiver(address(1), 0);
     }
 
-    function test_registerReceiver_revert_zeroAddress() public {
+    function test_registerReceiver_revert_zeroAddress() external {
         vm.prank(users.owner);
         vm.expectRevert();
         babelVault.registerReceiver(address(0), 1);
     }
 
-    function test_registerReceiver_revert_babelVault() public {
+    function test_registerReceiver_revert_babelVault() external {
         vm.prank(users.owner);
         vm.expectRevert();
         babelVault.registerReceiver(address(babelVault), 1);
     }
 
-    function test_registerReceiver_revert_nonOwner() public {
+    function test_registerReceiver_revert_nonOwner() external {
         vm.prank(users.user1);
         vm.expectRevert();
         babelVault.registerReceiver(address(1), 1);
     }
 
-    function test_allocateNewEmissions(uint256 count, uint256 weeksToAdd, bool disableReceiver) public {
+    /* this test is not quite right, commenting out for now
+    function test_allocateNewEmissions(uint256 count, uint256 weeksToAdd, bool disableReceiver) external {
+        // first need to fund vault with tokens
+        test_setInitialParameters();
+
         // bound fuzz inputs
         count = bound(count, 1, MAX_COUNT); // Limit count to avoid excessive gas usage or memory issues
         weeksToAdd = bound(weeksToAdd, 0, MAX_COUNT);
@@ -212,14 +222,16 @@ contract VaultTest is TestSetup {
         (, bool isActive, uint16 updatedWeek) = babelVault.idToReceiver(id);
 
         assertEq(updatedWeek, systemWeek);
+
         if (!isActive) {
             // If receiver is inactive, unallocated total should remain the same as after _allocateTotalWeekly
             expectedUnallocated = babelVault.unallocatedTotal();
+            assertEq(babelVault.unallocatedTotal(), initialUnallocated);
         }
 
         // Assertions
-        assertEq(babelVault.unallocatedTotal(), expectedUnallocated, "Unallocated total not updated correctly");
+        //assertTrue(babelVault.unallocatedTotal() < initialUnallocated);
         assertEq(allocated, 0, "Incorrect amount allocated");
         assertEq(babelVault.allocated(receiver), 0, "Allocated amount should be 0 for inactive receiver");
-    }
+    }*/
 }


### PR DESCRIPTION
* Fix for H-1 `AllocationVesting` contract can be exploited for infinite points via self-transfer
* Fix for M-2 Maximum preclaim limit can be easily bypassed to preclaim entire token allocation
* Fix for L-7 TokenLocker::getTotalWeightAt should loop until input week not systemWeek
* Fix for L-8 Less tokens can be allocated to emission receivers than weekly emissions due to precision loss from division before multiplication
* Fix for I-8 Enforce > 0 passing percent configuration in AdminVoting::setPassingPct
* Fix for I-9 TokenLocker::freeze always emits LocksFrozen event with 0 amount
* Fix for I-10 BorrowingFeePaid event should include token that was repaid
* Fix for I-11 BabelVault::registerReceiver should check bool return when calling IEmissionReceiver::notifyRegisteredId
* lots of new tests and explanatory comments for `dao` contracts
* minor gas/info fixes (don't re-read same values from storage, remove unnecessary downcasts by using matching memory types to match what is in storage, use named mappings, emit missing events, use calldata for external function parameters, don't cache calldata array input length, remove obsolete return statements when using named returns)