### PR TITLE
Fixes for H-2, L-9, L-10, L-11 plus more tests and minor info/gas

### DIFF
--- a/contracts/core/BorrowerOperations.sol
+++ b/contracts/core/BorrowerOperations.sol
@@ -117,7 +117,6 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
     function getTCR() external returns (uint256 globalTotalCollateralRatio) {
         SystemBalances memory balances = fetchBalances();
         (globalTotalCollateralRatio, , ) = _getTCRData(balances);
-        return globalTotalCollateralRatio;
     }
 
     /**
@@ -145,12 +144,12 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
         }
     }
 
-    function checkRecoveryMode(uint256 TCR) public pure returns (bool) {
-        return TCR < CCR;
+    function checkRecoveryMode(uint256 TCR) public pure returns (bool result) {
+        result = TCR < CCR;
     }
 
-    function getCompositeDebt(uint256 _debt) external view returns (uint256) {
-        return _getCompositeDebt(_debt);
+    function getCompositeDebt(uint256 _debt) external view returns (uint256 result) {
+        result = _getCompositeDebt(_debt);
     }
 
     // --- Borrower Trove Operations ---
@@ -419,16 +418,14 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
         address _caller,
         uint256 _maxFeePercentage,
         uint256 _debtAmount
-    ) internal returns (uint256) {
-        uint256 debtFee = _troveManager.decayBaseRateAndGetBorrowingFee(_debtAmount);
+    ) internal returns (uint256 debtFee) {
+        debtFee = _troveManager.decayBaseRateAndGetBorrowingFee(_debtAmount);
 
         _requireUserAcceptsFee(debtFee, _debtAmount, _maxFeePercentage);
 
         debtToken.mint(BABEL_CORE.feeReceiver(), debtFee);
 
         emit BorrowingFeePaid(_caller, collateralToken, debtFee);
-
-        return debtFee;
     }
 
     function _getCollChange(
@@ -533,7 +530,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
         uint256 _debtChange,
         bool _isDebtIncrease,
         uint256 _price
-    ) internal pure returns (uint256) {
+    ) internal pure returns (uint256 newICR) {
         (uint256 newColl, uint256 newDebt) = _getNewTroveAmounts(
             _coll,
             _debt,
@@ -543,8 +540,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
             _isDebtIncrease
         );
 
-        uint256 newICR = BabelMath._computeCR(newColl, newDebt, _price);
-        return newICR;
+        newICR = BabelMath._computeCR(newColl, newDebt, _price);
     }
 
     function _getNewTroveAmounts(
@@ -554,14 +550,9 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
         bool _isCollIncrease,
         uint256 _debtChange,
         bool _isDebtIncrease
-    ) internal pure returns (uint256, uint256) {
-        uint256 newColl = _coll;
-        uint256 newDebt = _debt;
-
+    ) internal pure returns (uint256 newColl, uint256 newDebt) {
         newColl = _isCollIncrease ? _coll + _collChange : _coll - _collChange;
         newDebt = _isDebtIncrease ? _debt + _debtChange : _debt - _debtChange;
-
-        return (newColl, newDebt);
     }
 
     function _getNewTCRFromTroveChange(
@@ -571,12 +562,11 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
         bool _isCollIncrease,
         uint256 _debtChange,
         bool _isDebtIncrease
-    ) internal pure returns (uint256) {
+    ) internal pure returns (uint256 newTCR) {
         totalDebt = _isDebtIncrease ? totalDebt + _debtChange : totalDebt - _debtChange;
         totalColl = _isCollIncrease ? totalColl + _collChange : totalColl - _collChange;
 
-        uint256 newTCR = BabelMath._computeCR(totalColl, totalDebt);
-        return newTCR;
+        newTCR = BabelMath._computeCR(totalColl, totalDebt);
     }
 
     function _getTCRData(
@@ -591,8 +581,6 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
             }
         }
         amount = BabelMath._computeCR(totalPricedCollateral, totalDebt);
-
-        return (amount, totalPricedCollateral, totalDebt);
     }
 
     function _getCollateralAndTCRData(
@@ -617,8 +605,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
         SystemBalances memory balances = fetchBalances();
         (amount, totalPricedCollateral, totalDebt) = _getTCRData(balances);
         isRecoveryMode = checkRecoveryMode(amount);
-
-        return (collateralToken, balances.prices[index], totalPricedCollateral, totalDebt, isRecoveryMode);
+        price = balances.prices[index];
     }
 
     function getGlobalSystemBalances() external returns (uint256 totalPricedCollateral, uint256 totalDebt) {

--- a/contracts/core/BorrowerOperations.sol
+++ b/contracts/core/BorrowerOperations.sol
@@ -6,6 +6,7 @@ import {BabelBase} from "../dependencies/BabelBase.sol";
 import {BabelMath} from "../dependencies/BabelMath.sol";
 import {BabelOwnable} from "../dependencies/BabelOwnable.sol";
 import {DelegatedOps} from "../dependencies/DelegatedOps.sol";
+import {BIMA_DECIMAL_PRECISION} from "../dependencies/Constants.sol";
 import {IBorrowerOperations, ITroveManager, IDebtToken} from "../interfaces/IBorrowerOperations.sol";
 
 /**
@@ -520,7 +521,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
     }
 
     function _requireValidMaxFeePercentage(uint256 _maxFeePercentage) internal pure {
-        require(_maxFeePercentage <= DECIMAL_PRECISION, "Max fee percentage must less than or equal to 100%");
+        require(_maxFeePercentage <= BIMA_DECIMAL_PRECISION, "Max fee percentage must less than or equal to 100%");
     }
 
     // Compute the new collateral ratio, considering the change in coll and debt. Assumes 0 pending rewards.

--- a/contracts/core/DebtToken.sol
+++ b/contracts/core/DebtToken.sol
@@ -5,6 +5,7 @@ import {OFT, IERC20, ERC20} from "@layerzerolabs/solidity-examples/contracts/tok
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {IERC3156FlashBorrower} from "@openzeppelin/contracts/interfaces/IERC3156FlashBorrower.sol";
 import {IBabelCore} from "../interfaces/IBabelCore.sol";
+import {BIMA_100_PCT} from "../dependencies/Constants.sol";
 
 /**
     @title Babel Debt Token "acUSD"
@@ -166,7 +167,7 @@ contract DebtToken is OFT {
      * @return fee applied to the corresponding flash loan.
      */
     function _flashFee(uint256 amount) internal pure returns (uint256 fee) {
-        fee = (amount * FLASH_LOAN_FEE) / 10000;
+        fee = (amount * FLASH_LOAN_FEE) / BIMA_100_PCT;
         require(fee > 0, "ERC20FlashMint: amount too small");
     }
 

--- a/contracts/core/Factory.sol
+++ b/contracts/core/Factory.sol
@@ -46,8 +46,8 @@ contract Factory is IFactory, BabelOwnable {
         liquidationManager = _liquidationManager;
     }
 
-    function troveManagerCount() external view returns (uint256) {
-        return troveManagers.length;
+    function troveManagerCount() external view returns (uint256 count) {
+        count = troveManagers.length;
     }
 
     /**

--- a/contracts/core/Factory.sol
+++ b/contracts/core/Factory.sol
@@ -107,5 +107,7 @@ contract Factory is IFactory, BabelOwnable {
     function setImplementations(address _troveManagerImpl, address _sortedTrovesImpl) external onlyOwner {
         troveManagerImpl = _troveManagerImpl;
         sortedTrovesImpl = _sortedTrovesImpl;
+
+        emit ImplementationContractsChanged(_troveManagerImpl, _sortedTrovesImpl);
     }
 }

--- a/contracts/core/LiquidationManager.sol
+++ b/contracts/core/LiquidationManager.sol
@@ -127,7 +127,8 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         @param borrower Borrower address to liquidate
      */
     function liquidate(ITroveManager troveManager, address borrower) external {
-        require(troveManager.getTroveStatus(borrower) == 1, "TroveManager: Trove does not exist or is closed");
+        require(troveManager.getTroveStatus(borrower) == ITroveManager.Status.active,
+                "TroveManager: Trove does not exist or is closed");
 
         address[] memory borrowers = new address[](1);
         borrowers[0] = borrower;

--- a/contracts/core/LiquidationManager.sol
+++ b/contracts/core/LiquidationManager.sol
@@ -433,7 +433,6 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             TroveManagerOperation.liquidateInNormalMode
         );
         emit TroveUpdated(_borrower, 0, 0, 0, TroveManagerOperation.liquidateInNormalMode);
-        return singleLiquidation;
     }
 
     /**
@@ -491,8 +490,6 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             TroveManagerOperation.liquidateInRecoveryMode
         );
         emit TroveUpdated(_borrower, 0, 0, 0, TroveManagerOperation.liquidateInRecoveryMode);
-
-        return singleLiquidation;
     }
 
     /**
@@ -532,7 +529,6 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             TroveManagerOperation.liquidateInRecoveryMode
         );
         emit TroveUpdated(_borrower, 0, 0, 0, TroveManagerOperation.liquidateInRecoveryMode);
-        return singleLiquidation;
     }
 
     /* In a full liquidation, returns the values for a trove's coll and debt to be offset, and coll and debt to be

--- a/contracts/core/PriceFeed.sol
+++ b/contracts/core/PriceFeed.sol
@@ -5,6 +5,7 @@ import {IPriceFeed, IAggregatorV3Interface} from "../interfaces/IPriceFeed.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {BabelMath} from "../dependencies/BabelMath.sol";
 import {BabelOwnable} from "../dependencies/BabelOwnable.sol";
+import {BIMA_DECIMAL_PRECISION} from "../dependencies/Constants.sol";
 
 /**
     @title Babel Multi Token Price Feed
@@ -247,7 +248,7 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
          * - If price decreased, the percentage deviation is in relation to the previous price.
          * - If price increased, the percentage deviation is in relation to the current price.
          */
-        uint256 percentDeviation = ((maxPrice - minPrice) * BabelMath.DECIMAL_PRECISION) / maxPrice;
+        uint256 percentDeviation = ((maxPrice - minPrice) * BIMA_DECIMAL_PRECISION) / maxPrice;
 
         return percentDeviation > MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND;
     }

--- a/contracts/core/PriceFeed.sol
+++ b/contracts/core/PriceFeed.sol
@@ -126,34 +126,37 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
         @dev You can obtain these values by calling `TroveManager.fetchPrice()`
              rather than directly interacting with this contract.
         @param _token Token to fetch the price for
-        @return The latest valid price for the requested token
+        @return price The latest valid price for the requested token
      */
-    function fetchPrice(address _token) public returns (uint256) {
+    function fetchPrice(address _token) public returns (uint256 price) {
         PriceRecord memory priceRecord = priceRecords[_token];
 
         if (priceRecord.lastUpdated == block.timestamp) {
             // We short-circuit only if the price was already correct in the current block
-            return priceRecord.scaledPrice;
+            price = priceRecord.scaledPrice;
         }
-        if (priceRecord.lastUpdated == 0) {
-            revert PriceFeed__UnknownFeedError(_token);
-        }
-
-        OracleRecord storage oracle = oracleRecords[_token];
-
-        (FeedResponse memory currResponse, FeedResponse memory prevResponse, bool updated) = _fetchFeedResponses(
-            oracle.chainLinkOracle,
-            priceRecord.roundId
-        );
-
-        if (!updated) {
-            if (_isPriceStale(priceRecord.timestamp, oracle.heartbeat)) {
-                revert PriceFeed__FeedFrozenError(_token);
+        else {
+            if (priceRecord.lastUpdated == 0) {
+                revert PriceFeed__UnknownFeedError(_token);
             }
-            return priceRecord.scaledPrice;
-        }
 
-        return _processFeedResponses(_token, oracle, currResponse, prevResponse, priceRecord);
+            OracleRecord storage oracle = oracleRecords[_token];
+
+            (FeedResponse memory currResponse, FeedResponse memory prevResponse, bool updated) = _fetchFeedResponses(
+                oracle.chainLinkOracle,
+                priceRecord.roundId
+            );
+
+            if (!updated) {
+                if (_isPriceStale(priceRecord.timestamp, oracle.heartbeat)) {
+                    revert PriceFeed__FeedFrozenError(_token);
+                }
+                price = priceRecord.scaledPrice;
+            }
+            else {
+                price = _processFeedResponses(_token, oracle, currResponse, prevResponse, priceRecord);
+            }
+        }
     }
 
     // Internal functions -----------------------------------------------------------------------------------------------
@@ -164,13 +167,15 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
         FeedResponse memory _currResponse,
         FeedResponse memory _prevResponse,
         PriceRecord memory priceRecord
-    ) internal returns (uint256) {
+    ) internal returns (uint256 scaledPrice) {
         uint8 decimals = oracle.decimals;
         bool isValidResponse = _isFeedWorking(_currResponse, _prevResponse) &&
             !_isPriceStale(_currResponse.timestamp, oracle.heartbeat) &&
             !_isPriceChangeAboveMaxDeviation(_currResponse, _prevResponse, decimals);
+
         if (isValidResponse) {
-            uint256 scaledPrice = _scalePriceByDigits(uint256(_currResponse.answer), decimals);
+            scaledPrice = _scalePriceByDigits(uint256(_currResponse.answer), decimals);
+
             if (oracle.sharePriceSignature != 0) {
                 (bool success, bytes memory returnData) = _token.staticcall(abi.encode(oracle.sharePriceSignature));
                 require(success, "Share price not available");
@@ -184,21 +189,21 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
                 _updateFeedStatus(_token, oracle, true);
             }
             _storePrice(_token, scaledPrice, _currResponse.timestamp, _currResponse.roundId);
-            return scaledPrice;
-        } else {
+        } 
+        else {
             if (oracle.isFeedWorking) {
                 _updateFeedStatus(_token, oracle, false);
             }
             if (_isPriceStale(priceRecord.timestamp, oracle.heartbeat)) {
                 revert PriceFeed__FeedFrozenError(_token);
             }
-            return priceRecord.scaledPrice;
+            scaledPrice = priceRecord.scaledPrice;
         }
     }
 
-    function _calcEthPrice(uint256 ethAmount) internal returns (uint256) {
+    function _calcEthPrice(uint256 ethAmount) internal returns (uint256 price) {
         uint256 ethPrice = fetchPrice(address(0));
-        return (ethPrice * ethAmount) / 1 ether;
+        price = (ethPrice * ethAmount) / 1 ether;
     }
 
     function _fetchFeedResponses(
@@ -212,19 +217,19 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
         }
     }
 
-    function _isPriceStale(uint256 _priceTimestamp, uint256 _heartbeat) internal view returns (bool) {
-        return block.timestamp - _priceTimestamp > _heartbeat + RESPONSE_TIMEOUT_BUFFER;
+    function _isPriceStale(uint256 _priceTimestamp, uint256 _heartbeat) internal view returns (bool isPriceStale) {
+        isPriceStale = block.timestamp - _priceTimestamp > _heartbeat + RESPONSE_TIMEOUT_BUFFER;
     }
 
     function _isFeedWorking(
         FeedResponse memory _currentResponse,
         FeedResponse memory _prevResponse
-    ) internal view returns (bool) {
-        return _isValidResponse(_currentResponse) && _isValidResponse(_prevResponse);
+    ) internal view returns (bool isFeedWorking) {
+        isFeedWorking = _isValidResponse(_currentResponse) && _isValidResponse(_prevResponse);
     }
 
-    function _isValidResponse(FeedResponse memory _response) internal view returns (bool) {
-        return
+    function _isValidResponse(FeedResponse memory _response) internal view returns (bool isValidResponse) {
+        isValidResponse =
             (_response.success) &&
             (_response.roundId != 0) &&
             (_response.timestamp != 0) &&
@@ -236,7 +241,7 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
         FeedResponse memory _currResponse,
         FeedResponse memory _prevResponse,
         uint8 decimals
-    ) internal pure returns (bool) {
+    ) internal pure returns (bool isPriceChangeAboveMaxDeviation) {
         uint256 currentScaledPrice = _scalePriceByDigits(uint256(_currResponse.answer), decimals);
         uint256 prevScaledPrice = _scalePriceByDigits(uint256(_prevResponse.answer), decimals);
 
@@ -250,18 +255,18 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
          */
         uint256 percentDeviation = ((maxPrice - minPrice) * BIMA_DECIMAL_PRECISION) / maxPrice;
 
-        return percentDeviation > MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND;
+        isPriceChangeAboveMaxDeviation = percentDeviation > MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND;
     }
 
-    function _scalePriceByDigits(uint256 _price, uint256 _answerDigits) internal pure returns (uint256) {
+    function _scalePriceByDigits(uint256 _price, uint256 _answerDigits) internal pure returns (uint256 scaledPrice) {
         if (_answerDigits == TARGET_DIGITS) {
-            return _price;
+            scaledPrice = _price;
         } else if (_answerDigits < TARGET_DIGITS) {
             // Scale the returned price value up to target precision
-            return _price * (10 ** (TARGET_DIGITS - _answerDigits));
+            scaledPrice = _price * (10 ** (TARGET_DIGITS - _answerDigits));
         } else {
             // Scale the returned price value down to target precision
-            return _price / (10 ** (_answerDigits - TARGET_DIGITS));
+            scaledPrice = _price / (10 ** (_answerDigits - TARGET_DIGITS));
         }
     }
 
@@ -296,8 +301,8 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
             response.timestamp = timestamp;
             response.success = true;
         } catch {
-            // If call to Chainlink aggregator reverts, return a zero response with success = false
-            return response;
+            // If call to Chainlink aggregator reverts
+            // return default zero response with success = false
         }
     }
 
@@ -305,22 +310,21 @@ contract PriceFeed is IPriceFeed, BabelOwnable {
         IAggregatorV3Interface _priceAggregator,
         uint80 _currentRoundId
     ) internal view returns (FeedResponse memory prevResponse) {
-        if (_currentRoundId == 0) {
-            return prevResponse;
-        }
-        unchecked {
-            try _priceAggregator.getRoundData(_currentRoundId - 1) returns (
-                uint80 roundId,
-                int256 answer,
-                uint256 /* startedAt */,
-                uint256 timestamp,
-                uint80 /* answeredInRound */
-            ) {
-                prevResponse.roundId = roundId;
-                prevResponse.answer = answer;
-                prevResponse.timestamp = timestamp;
-                prevResponse.success = true;
-            } catch {}
+        if (_currentRoundId != 0) {
+            unchecked {
+                try _priceAggregator.getRoundData(_currentRoundId - 1) returns (
+                    uint80 roundId,
+                    int256 answer,
+                    uint256 /* startedAt */,
+                    uint256 timestamp,
+                    uint80 /* answeredInRound */
+                ) {
+                    prevResponse.roundId = roundId;
+                    prevResponse.answer = answer;
+                    prevResponse.timestamp = timestamp;
+                    prevResponse.success = true;
+                } catch {}
+            }
         }
     }
 }

--- a/contracts/core/SortedTroves.sol
+++ b/contracts/core/SortedTroves.sol
@@ -182,52 +182,52 @@ contract SortedTroves is ISortedTroves {
     /*
      * @dev Checks if the list contains a node
      */
-    function contains(address _id) public view returns (bool) {
-        return data.nodes[_id].exists;
+    function contains(address _id) public view returns (bool result) {
+        result = data.nodes[_id].exists;
     }
 
     /*
      * @dev Checks if the list is empty
      */
-    function isEmpty() public view returns (bool) {
-        return data.size == 0;
+    function isEmpty() public view returns (bool result) {
+        result = data.size == 0;
     }
 
     /*
      * @dev Returns the current size of the list
      */
-    function getSize() external view returns (uint256) {
-        return data.size;
+    function getSize() external view returns (uint256 result) {
+        result = data.size;
     }
 
     /*
      * @dev Returns the first node in the list (node with the largest NICR)
      */
-    function getFirst() external view returns (address) {
-        return data.head;
+    function getFirst() external view returns (address result) {
+        result = data.head;
     }
 
     /*
      * @dev Returns the last node in the list (node with the smallest NICR)
      */
-    function getLast() external view returns (address) {
-        return data.tail;
+    function getLast() external view returns (address result) {
+        result = data.tail;
     }
 
     /*
      * @dev Returns the next node (with a smaller NICR) in the list for a given node
      * @param _id Node's id
      */
-    function getNext(address _id) external view returns (address) {
-        return data.nodes[_id].nextId;
+    function getNext(address _id) external view returns (address result) {
+        result = data.nodes[_id].nextId;
     }
 
     /*
      * @dev Returns the previous node (with a larger NICR) in the list for a given node
      * @param _id Node's id
      */
-    function getPrev(address _id) external view returns (address) {
-        return data.nodes[_id].prevId;
+    function getPrev(address _id) external view returns (address result) {
+        result = data.nodes[_id].prevId;
     }
 
     /*
@@ -236,8 +236,8 @@ contract SortedTroves is ISortedTroves {
      * @param _prevId Id of previous node for the insert position
      * @param _nextId Id of next node for the insert position
      */
-    function validInsertPosition(uint256 _NICR, address _prevId, address _nextId) external view returns (bool) {
-        return _validInsertPosition(troveManager, _NICR, _prevId, _nextId);
+    function validInsertPosition(uint256 _NICR, address _prevId, address _nextId) external view returns (bool result) {
+        result = _validInsertPosition(troveManager, _NICR, _prevId, _nextId);
     }
 
     function _validInsertPosition(
@@ -245,19 +245,19 @@ contract SortedTroves is ISortedTroves {
         uint256 _NICR,
         address _prevId,
         address _nextId
-    ) internal view returns (bool) {
+    ) internal view returns (bool result) {
         if (_prevId == address(0) && _nextId == address(0)) {
             // `(null, null)` is a valid insert position if the list is empty
-            return isEmpty();
+            result = isEmpty();
         } else if (_prevId == address(0)) {
             // `(null, _nextId)` is a valid insert position if `_nextId` is the head of the list
-            return data.head == _nextId && _NICR >= _troveManager.getNominalICR(_nextId);
+            result = data.head == _nextId && _NICR >= _troveManager.getNominalICR(_nextId);
         } else if (_nextId == address(0)) {
             // `(_prevId, null)` is a valid insert position if `_prevId` is the tail of the list
-            return data.tail == _prevId && _NICR <= _troveManager.getNominalICR(_prevId);
+            result = data.tail == _prevId && _NICR <= _troveManager.getNominalICR(_prevId);
         } else {
             // `(_prevId, _nextId)` is a valid insert position if they are adjacent nodes and `_NICR` falls between the two nodes' NICRs
-            return
+            result =
                 data.nodes[_prevId].nextId == _nextId &&
                 _troveManager.getNominalICR(_prevId) >= _NICR &&
                 _NICR >= _troveManager.getNominalICR(_nextId);
@@ -274,22 +274,20 @@ contract SortedTroves is ISortedTroves {
         ITroveManager _troveManager,
         uint256 _NICR,
         address _startId
-    ) internal view returns (address, address) {
+    ) internal view returns (address prevId, address nextId) {
         // If `_startId` is the head, check if the insert position is before the head
         if (data.head == _startId && _NICR >= _troveManager.getNominalICR(_startId)) {
             return (address(0), _startId);
         }
 
-        address prevId = _startId;
-        address nextId = data.nodes[prevId].nextId;
+        prevId = _startId;
+        nextId = data.nodes[prevId].nextId;
 
         // Descend the list until we reach the end or until we find a valid insert position
         while (prevId != address(0) && !_validInsertPosition(_troveManager, _NICR, prevId, nextId)) {
             prevId = data.nodes[prevId].nextId;
             nextId = data.nodes[prevId].nextId;
         }
-
-        return (prevId, nextId);
     }
 
     /*
@@ -302,22 +300,20 @@ contract SortedTroves is ISortedTroves {
         ITroveManager _troveManager,
         uint256 _NICR,
         address _startId
-    ) internal view returns (address, address) {
+    ) internal view returns (address prevId, address nextId) {
         // If `_startId` is the tail, check if the insert position is after the tail
         if (data.tail == _startId && _NICR <= _troveManager.getNominalICR(_startId)) {
             return (_startId, address(0));
         }
 
-        address nextId = _startId;
-        address prevId = data.nodes[nextId].prevId;
+        nextId = _startId;
+        prevId = data.nodes[nextId].prevId;
 
         // Ascend the list until we reach the end or until we find a valid insertion point
         while (nextId != address(0) && !_validInsertPosition(_troveManager, _NICR, prevId, nextId)) {
             nextId = data.nodes[nextId].prevId;
             prevId = data.nodes[nextId].prevId;
         }
-
-        return (prevId, nextId);
     }
 
     /*
@@ -330,8 +326,8 @@ contract SortedTroves is ISortedTroves {
         uint256 _NICR,
         address _prevId,
         address _nextId
-    ) external view returns (address, address) {
-        return _findInsertPosition(troveManager, _NICR, _prevId, _nextId);
+    ) external view returns (address prevId, address nextId) {
+        (prevId, nextId) = _findInsertPosition(troveManager, _NICR, _prevId, _nextId);
     }
 
     function _findInsertPosition(
@@ -339,9 +335,9 @@ contract SortedTroves is ISortedTroves {
         uint256 _NICR,
         address _prevId,
         address _nextId
-    ) internal view returns (address, address) {
-        address prevId = _prevId;
-        address nextId = _nextId;
+    ) internal view returns (address prevId, address nextId) {
+        prevId = _prevId;
+        nextId = _nextId;
 
         if (prevId != address(0)) {
             if (!contains(prevId) || _NICR > _troveManager.getNominalICR(prevId)) {
@@ -359,16 +355,16 @@ contract SortedTroves is ISortedTroves {
 
         if (prevId == address(0) && nextId == address(0)) {
             // No hint - descend list starting from head
-            return _descendList(_troveManager, _NICR, data.head);
+            (prevId, nextId) = _descendList(_troveManager, _NICR, data.head);
         } else if (prevId == address(0)) {
             // No `prevId` for hint - ascend list starting from `nextId`
-            return _ascendList(_troveManager, _NICR, nextId);
+            (prevId, nextId) = _ascendList(_troveManager, _NICR, nextId);
         } else if (nextId == address(0)) {
             // No `nextId` for hint - descend list starting from `prevId`
-            return _descendList(_troveManager, _NICR, prevId);
+            (prevId, nextId) = _descendList(_troveManager, _NICR, prevId);
         } else {
             // Descend list starting from `prevId`
-            return _descendList(_troveManager, _NICR, prevId);
+            (prevId, nextId) = _descendList(_troveManager, _NICR, prevId);
         }
     }
 

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -22,7 +22,9 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
     uint128 public constant SUNSET_DURATION = 180 days;
     uint256 constant REWARD_DURATION = 1 weeks;
 
-    uint256 public constant emissionId = 0;
+    // stability pool is registered with receiver ID 0
+    // in BabelVault::constructor
+    uint256 public constant SP_EMISSION_ID = 0;
 
     IDebtToken public immutable debtToken;
     IBabelVault public immutable vault;
@@ -285,7 +287,7 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
         uint256 lastUpdateWeek = (_periodFinish - startTime) / 1 weeks;
         // If the last claim was a week earlier we reclaim
         if (getWeek() >= lastUpdateWeek) {
-            uint256 amount = vault.allocateNewEmissions(emissionId);
+            uint256 amount = vault.allocateNewEmissions(SP_EMISSION_ID);
             if (amount > 0) {
                 // If the previous period is not finished we combine new and pending old rewards
                 if (block.timestamp < _periodFinish) {

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -714,7 +714,7 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
     }
 
     // --- Sender functions for Debt deposit, collateral gains and Babel gains ---
-    function claimCollateralGains(address recipient, uint256[] calldata collateralIndexes) external virtual {
+    function claimCollateralGains(address recipient, uint256[] calldata collateralIndexes) external {
         // accrue user collateral gains prior to claiming
         _accrueDepositorCollateralGain(msg.sender);
 

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -274,7 +274,8 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
 
     /*  provideToSP():
      *
-     * - Triggers a Babel issuance, based on time passed since the last issuance. The Babel issuance is shared between *all* depositors and front ends
+     * - Triggers a Babel issuance, based on time passed since the last issuance.
+     *   The Babel issuance is shared between *all* depositors and front ends
      * - Tags the deposit with the provided front end tag param, if it's a new deposit
      * - Sends depositor's accumulated gains (Babel, collateral) to depositor
      * - Sends the tagged front end's accumulated Babel gains to the tagged front end
@@ -714,10 +715,9 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
 
     // --- Sender functions for Debt deposit, collateral gains and Babel gains ---
     function claimCollateralGains(address recipient, uint256[] calldata collateralIndexes) external virtual {
-        _claimCollateralGains(recipient, collateralIndexes);
-    }
+        // accrue user collateral gains prior to claiming
+        _accrueDepositorCollateralGain(msg.sender);
 
-    function _claimCollateralGains(address recipient, uint256[] calldata collateralIndexes) internal {
         uint256[] memory collateralGains = new uint256[](collateralTokens.length);
 
         uint80[256] storage depositorGains = collateralGainsByDepositor[msg.sender];

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -550,7 +550,7 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
          * The newProductFactor is the factor by which to change all deposits, due to the depletion of Stability Pool Debt in the liquidation.
          * We make the product factor 0 if there was a pool-emptying. Otherwise, it is (1 - DebtLossPerUnitStaked)
          */
-        uint256 newProductFactor = uint256(BIMA_DECIMAL_PRECISION) - _debtLossPerUnitStaked;
+        uint256 newProductFactor = BIMA_DECIMAL_PRECISION - _debtLossPerUnitStaked;
 
         uint128 currentScaleCached = currentScale;
         uint128 currentEpochCached = currentEpoch;
@@ -652,7 +652,7 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
                 uint256 firstPortion = sumS[i] - depSums[i];
                 uint256 secondPortion = nextSumS[i] / BIMA_SCALE_FACTOR;
 
-                depositorGains[i] += uint80(
+                depositorGains[i] += SafeCast.toUint80(
                     (initialDeposit * (firstPortion + secondPortion)) / P_Snapshot / BIMA_DECIMAL_PRECISION
                 );
             }

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -5,7 +5,7 @@ import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol
 import {BabelOwnable} from "../dependencies/BabelOwnable.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
 import {BabelMath} from "../dependencies/BabelMath.sol";
-import {BIMA_DECIMAL_PRECISION, BIMA_SCALE_FACTOR} from "../dependencies/Constants.sol";
+import {BIMA_DECIMAL_PRECISION, BIMA_SCALE_FACTOR, BIMA_REWARD_DURATION} from "../dependencies/Constants.sol";
 import {IStabilityPool, IDebtToken, IBabelVault, IERC20} from "../interfaces/IStabilityPool.sol";
 
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
@@ -23,7 +23,6 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
 
     // constants
     uint128 public constant SUNSET_DURATION = 180 days;
-    uint256 constant REWARD_DURATION = 1 weeks;
     uint256 constant MAX_COLLATERAL_COUNT = 256;
 
     // stability pool is registered with receiver ID 0
@@ -396,8 +395,8 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
                     amount += remaining * rewardRate;
                 }
 
-                rewardRate = SafeCast.toUint128(amount / REWARD_DURATION);
-                periodFinish = uint32(block.timestamp + REWARD_DURATION);
+                rewardRate = SafeCast.toUint128(amount / BIMA_REWARD_DURATION);
+                periodFinish = uint32(block.timestamp + BIMA_REWARD_DURATION);
             }
         }
 

--- a/contracts/core/StorkOracleWrapper.sol
+++ b/contracts/core/StorkOracleWrapper.sol
@@ -34,16 +34,16 @@ contract StorkOracleWrapper is IAggregatorV3Interface {
     storkOracle.getTemporalNumericValueV1(encodedAssetId);
   }
 
-  function decimals() external pure returns (uint8) {
-    return 8;
+  function decimals() external pure returns (uint8 dec) {
+    dec = 8;
   }
 
-  function description() external pure returns (string memory) {
-    return "AggregatorV3Interface Wrapper for Stork Oracle";
+  function description() external pure returns (string memory desc) {
+    desc = "AggregatorV3Interface Wrapper for Stork Oracle";
   }
 
-  function version() external pure returns (uint256) {
-    return 1;
+  function version() external pure returns (uint256 ver) {
+    ver = 1;
   }
 
   function getRoundData(

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -361,8 +361,8 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         owners = TroveOwners[_index];
     }
 
-    function getTroveStatus(address _borrower) external view returns (uint256 status) {
-        status = uint256(Troves[_borrower].status);
+    function getTroveStatus(address _borrower) external view returns (Status status) {
+        status = Troves[_borrower].status;
     }
 
     function getTroveStake(address _borrower) external view returns (uint256 stake) {

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -10,7 +10,7 @@ import {SystemStart} from "../dependencies/SystemStart.sol";
 import {BabelBase} from "../dependencies/BabelBase.sol";
 import {BabelMath} from "../dependencies/BabelMath.sol";
 import {BabelOwnable} from "../dependencies/BabelOwnable.sol";
-import {BIMA_100_PCT, BIMA_DECIMAL_PRECISION} from "../dependencies/Constants.sol";
+import {BIMA_100_PCT, BIMA_DECIMAL_PRECISION, BIMA_REWARD_DURATION} from "../dependencies/Constants.sol";
 
 // todo: remove before production
 import {console} from "hardhat/console.sol";
@@ -50,7 +50,6 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
     uint256 constant SECONDS_IN_ONE_MINUTE = 60;
     uint256 constant INTEREST_PRECISION = 1e27;
     uint256 constant SECONDS_IN_YEAR = 365 days;
-    uint256 constant REWARD_DURATION = 1 weeks;
 
     // volume-based amounts are divided by this value to allow storing as uint32
     uint256 constant VOLUME_MULTIPLIER = 1e20;
@@ -904,9 +903,9 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
             uint256 remaining = _periodFinish - block.timestamp;
             amount += remaining * rewardRate;
         }
-        rewardRate = uint128(amount / REWARD_DURATION);
+        rewardRate = uint128(amount / BIMA_REWARD_DURATION);
         lastUpdate = uint32(block.timestamp);
-        periodFinish = uint32(block.timestamp + REWARD_DURATION);
+        periodFinish = uint32(block.timestamp + BIMA_REWARD_DURATION);
 
         // minting rewards
         amount = vault.allocateNewEmissions(id.minting);

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -762,7 +762,7 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         // Update Trove Manager debt, and send collateral to account
         totalActiveDebt = totalActiveDebt - totals.totalDebtToRedeem;
         _sendCollateral(msg.sender, totals.collateralToSendToRedeemer);
-        
+
         _resetState();
     }
 
@@ -981,7 +981,7 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
             uint256 remaining = _periodFinish - block.timestamp;
             amount += remaining * rewardRate;
         }
-        rewardRate = uint128(amount / BIMA_REWARD_DURATION);
+        rewardRate = SafeCast.toUint128(amount / BIMA_REWARD_DURATION);
         lastUpdate = uint32(block.timestamp);
         periodFinish = uint32(block.timestamp + BIMA_REWARD_DURATION);
 

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -384,12 +384,16 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
     }
 
     function collectInterests() external {
+        // checks
         uint256 interestPayableCached = interestPayable;
         require(interestPayableCached > 0, "Nothing to collect");
-        debtToken.mint(BABEL_CORE.feeReceiver(), interestPayableCached);
-        interestPayable = 0;
 
+        // effects
+        interestPayable = 0;
         emit CollectedInterest(interestPayableCached);
+
+        // interactions
+        debtToken.mint(BABEL_CORE.feeReceiver(), interestPayableCached);
     }
 
     // --- Getters ---

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -463,10 +463,12 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         coll = coll + pendingCollateralReward;
     }
 
+    // includes defaulted collateral
     function getEntireSystemColl() public view returns (uint256 coll) {
         coll = totalActiveCollateral + defaultedCollateral;
     }
 
+    // includes defaulted debt
     function getEntireSystemDebt() public view returns (uint256 debt) {
         debt = totalActiveDebt;
 
@@ -500,16 +502,18 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         ICR = BabelMath._computeCR(currentCollateral, currentDebt, _price);
     }
 
+    // excludes defaulted collateral
     function getTotalActiveCollateral() public view returns (uint256 currentActiveCollateral) {
         currentActiveCollateral = totalActiveCollateral;
     }
 
+    // excludes defaulted debt
     function getTotalActiveDebt() public view returns (uint256 currentActiveDebt) {
         currentActiveDebt = totalActiveDebt;
+
         (, uint256 interestFactor) = _calculateInterestIndex();
         if (interestFactor > 0) {
-            uint256 activeInterests = Math.mulDiv(currentActiveDebt, interestFactor, INTEREST_PRECISION);
-            currentActiveDebt = currentActiveDebt + activeInterests;
+            currentActiveDebt += Math.mulDiv(currentActiveDebt, interestFactor, INTEREST_PRECISION);
         }
     }
 

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -10,6 +10,7 @@ import {SystemStart} from "../dependencies/SystemStart.sol";
 import {BabelBase} from "../dependencies/BabelBase.sol";
 import {BabelMath} from "../dependencies/BabelMath.sol";
 import {BabelOwnable} from "../dependencies/BabelOwnable.sol";
+import {BIMA_100_PCT} from "../dependencies/Constants.sol";
 
 // todo: remove before production
 import {console} from "hardhat/console.sol";
@@ -57,7 +58,7 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
     // Maximum interest rate must be lower than the minimum LST staking yield
     // so that over time the actual TCR becomes greater than the calculated TCR.
     uint256 public constant MAX_INTEREST_RATE_IN_BPS = 400; // 4%
-    uint256 public constant SUNSETTING_INTEREST_RATE = (INTEREST_PRECISION * 5000) / (10000 * SECONDS_IN_YEAR); //50%
+    uint256 public constant SUNSETTING_INTEREST_RATE = (INTEREST_PRECISION * 5000) / (BIMA_100_PCT * SECONDS_IN_YEAR); //50%
 
     // During bootsrap period redemptions are not allowed
     uint256 public constant BOOTSTRAP_PERIOD = 14 days;

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -468,13 +468,14 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
     }
 
     function getEntireSystemDebt() public view returns (uint256 debt) {
-        uint256 currentActiveDebt = totalActiveDebt;
+        debt = totalActiveDebt;
+
         (, uint256 interestFactor) = _calculateInterestIndex();
         if (interestFactor > 0) {
-            uint256 activeInterests = Math.mulDiv(currentActiveDebt, interestFactor, INTEREST_PRECISION);
-            currentActiveDebt = currentActiveDebt + activeInterests;
+            debt += Math.mulDiv(debt, interestFactor, INTEREST_PRECISION);
         }
-        debt = currentActiveDebt + defaultedDebt;
+
+        debt += defaultedDebt;
     }
 
     function getEntireSystemBalances() external returns (uint256 coll, uint256 debt, uint256 price) {

--- a/contracts/core/helpers/MultiCollateralHintHelpers.sol
+++ b/contracts/core/helpers/MultiCollateralHintHelpers.sol
@@ -107,39 +107,38 @@ contract MultiCollateralHintHelpers is BabelBase {
         ISortedTroves sortedTroves = ISortedTroves(troveManager.sortedTroves());
         uint256 arrayLength = troveManager.getTroveOwnersCount();
 
-        if (arrayLength == 0) {
-            return (address(0), 0, _inputRandomSeed);
-        }
-
-        hintAddress = sortedTroves.getLast();
-        diff = BabelMath._getAbsoluteDifference(_CR, troveManager.getNominalICR(hintAddress));
         latestRandomSeed = _inputRandomSeed;
 
-        uint256 i = 1;
+        if (arrayLength != 0) {
+            hintAddress = sortedTroves.getLast();
+            diff = BabelMath._getAbsoluteDifference(_CR, troveManager.getNominalICR(hintAddress));
 
-        while (i < _numTrials) {
-            latestRandomSeed = uint256(keccak256(abi.encodePacked(latestRandomSeed)));
+            uint256 i = 1;
 
-            uint256 arrayIndex = latestRandomSeed % arrayLength;
-            address currentAddress = troveManager.getTroveFromTroveOwnersArray(arrayIndex);
-            uint256 currentNICR = troveManager.getNominalICR(currentAddress);
+            while (i < _numTrials) {
+                latestRandomSeed = uint256(keccak256(abi.encodePacked(latestRandomSeed)));
 
-            // check if abs(current - CR) > abs(closest - CR), and update closest if current is closer
-            uint256 currentDiff = BabelMath._getAbsoluteDifference(currentNICR, _CR);
+                uint256 arrayIndex = latestRandomSeed % arrayLength;
+                address currentAddress = troveManager.getTroveFromTroveOwnersArray(arrayIndex);
+                uint256 currentNICR = troveManager.getNominalICR(currentAddress);
 
-            if (currentDiff < diff) {
-                diff = currentDiff;
-                hintAddress = currentAddress;
+                // check if abs(current - CR) > abs(closest - CR), and update closest if current is closer
+                uint256 currentDiff = BabelMath._getAbsoluteDifference(currentNICR, _CR);
+
+                if (currentDiff < diff) {
+                    diff = currentDiff;
+                    hintAddress = currentAddress;
+                }
+                i++;
             }
-            i++;
         }
     }
 
-    function computeNominalCR(uint256 _coll, uint256 _debt) external pure returns (uint256) {
-        return BabelMath._computeNominalCR(_coll, _debt);
+    function computeNominalCR(uint256 _coll, uint256 _debt) external pure returns (uint256 result) {
+        result = BabelMath._computeNominalCR(_coll, _debt);
     }
 
-    function computeCR(uint256 _coll, uint256 _debt, uint256 _price) external pure returns (uint256) {
-        return BabelMath._computeCR(_coll, _debt, _price);
+    function computeCR(uint256 _coll, uint256 _debt, uint256 _price) external pure returns (uint256 result) {
+        result = BabelMath._computeCR(_coll, _debt, _price);
     }
 }

--- a/contracts/core/helpers/MultiCollateralHintHelpers.sol
+++ b/contracts/core/helpers/MultiCollateralHintHelpers.sol
@@ -7,6 +7,7 @@ import {ISortedTroves} from "../../interfaces/ISortedTroves.sol";
 import {IFactory} from "../../interfaces/IFactory.sol";
 import {BabelBase} from "../../dependencies/BabelBase.sol";
 import {BabelMath} from "../../dependencies/BabelMath.sol";
+import {BIMA_DECIMAL_PRECISION} from "../../dependencies/Constants.sol";
 
 contract MultiCollateralHintHelpers is BabelBase {
     IBorrowerOperations public immutable borrowerOperations;
@@ -69,7 +70,7 @@ contract MultiCollateralHintHelpers is BabelBase {
                 if (netDebt > minNetDebt) {
                     uint256 maxRedeemableDebt = BabelMath._min(remainingDebt, netDebt - minNetDebt);
 
-                    uint256 newColl = coll - ((maxRedeemableDebt * DECIMAL_PRECISION) / _price);
+                    uint256 newColl = coll - ((maxRedeemableDebt * BIMA_DECIMAL_PRECISION) / _price);
                     uint256 newDebt = netDebt - maxRedeemableDebt;
 
                     uint256 compositeDebt = _getCompositeDebt(newDebt);

--- a/contracts/core/helpers/TroveManagerGetters.sol
+++ b/contracts/core/helpers/TroveManagerGetters.sol
@@ -21,7 +21,7 @@ contract TroveManagerGetters {
         @notice Returns all active system trove managers and collaterals, as an
         `       array of tuples of [(collateral, [troveManager, ...]), ...]
      */
-    function getAllCollateralsAndTroveManagers() external view returns (Collateral[] memory) {
+    function getAllCollateralsAndTroveManagers() external view returns (Collateral[] memory collateralMap) {
         uint256 length = factory.troveManagerCount();
         address[2][] memory troveManagersAndCollaterals = new address[2][](length);
         address[] memory uniqueCollaterals = new address[](length);
@@ -39,7 +39,8 @@ contract TroveManagerGetters {
                 }
             }
         }
-        Collateral[] memory collateralMap = new Collateral[](collateralCount);
+        
+        collateralMap = new Collateral[](collateralCount);
         for (uint256 i; i < collateralCount; i++) {
             collateralMap[i].collateral = uniqueCollaterals[i];
             uint256 tmCollCount;
@@ -55,16 +56,14 @@ contract TroveManagerGetters {
                 collateralMap[i].troveManagers[x] = troveManagers[x];
             }
         }
-
-        return collateralMap;
     }
 
     /**
         @notice Returns a list of trove managers where `account` has an existing trove
      */
-    function getActiveTroveManagersForAccount(address account) external view returns (address[] memory) {
+    function getActiveTroveManagersForAccount(address account) external view returns (address[] memory troveManagers) {
         uint256 length = factory.troveManagerCount();
-        address[] memory troveManagers = new address[](length);
+        troveManagers = new address[](length);
         uint256 tmCount;
         for (uint256 i; i < length; i++) {
             address troveManager = factory.troveManagers(i);
@@ -76,6 +75,5 @@ contract TroveManagerGetters {
         assembly {
             mstore(troveManagers, tmCount)
         }
-        return troveManagers;
     }
 }

--- a/contracts/core/helpers/TroveManagerGetters.sol
+++ b/contracts/core/helpers/TroveManagerGetters.sol
@@ -67,7 +67,8 @@ contract TroveManagerGetters {
         uint256 tmCount;
         for (uint256 i; i < length; i++) {
             address troveManager = factory.troveManagers(i);
-            if (ITroveManager(troveManager).getTroveStatus(account) > 0) {
+
+            if (ITroveManager(troveManager).getTroveStatus(account) != ITroveManager.Status.nonExistent) {
                 troveManagers[tmCount] = troveManager;
                 tmCount++;
             }

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {DelegatedOps} from "../dependencies/DelegatedOps.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
+import {BIMA_100_PCT} from "../dependencies/Constants.sol";
 import {ITokenLocker} from "../interfaces/ITokenLocker.sol";
 import {IBabelCore} from "../interfaces/IBabelCore.sol";
 
@@ -73,8 +74,6 @@ contract AdminVoting is DelegatedOps, SystemStart {
     // account last proposal creation timestamps
     mapping(address account => uint256 timestamp) public latestProposalTimestamp;
 
-    // percentages are expressed as a whole number out of `MAX_PCT`
-    uint256 public constant MAX_PCT = 10000;
     // percent of total weight required to create a new proposal
     uint256 public minCreateProposalPct;
     // percent of total weight that must vote for a proposal before it can be executed
@@ -120,7 +119,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         require(weight > 0, "Zero total voting weight for given week");
 
         // over-write output return with weight calculation
-        weight = (weight * minCreateProposalPct / MAX_PCT);
+        weight = (weight * minCreateProposalPct / BIMA_100_PCT);
     }
 
     /**
@@ -242,7 +241,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         uint256 totalWeight = tokenLocker.getTotalWeightAt(week);
 
         // calculate required quorum for the proposal to pass
-        uint40 requiredWeight = SafeCast.toUint40((totalWeight * proposalPassPct) / MAX_PCT);
+        uint40 requiredWeight = SafeCast.toUint40((totalWeight * proposalPassPct) / BIMA_100_PCT);
 
         // output newly created proposal id
         proposalId = proposalData.length;
@@ -419,7 +418,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         require(msg.sender == address(this), "Only callable via proposal");
 
         // restrict max value
-        require(pct <= MAX_PCT, "Invalid value");
+        require(pct <= BIMA_100_PCT, "Invalid value");
 
         // update to new value
         minCreateProposalPct = pct;
@@ -439,7 +438,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         require(msg.sender == address(this), "Only callable via proposal");
 
         // restrict max value
-        require(pct <= MAX_PCT && pct > 0, "Invalid value");
+        require(pct <= BIMA_100_PCT && pct > 0, "Invalid value");
 
         // update to new value
         passingPct = pct;

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -95,8 +95,8 @@ contract AdminVoting is DelegatedOps, SystemStart {
     /**
         @notice The total number of votes created
      */
-    function getProposalCount() external view returns (uint256) {
-        return proposalData.length;
+    function getProposalCount() external view returns (uint256 count) {
+        count = proposalData.length;
     }
 
     function minCreateProposalWeight() external view returns (uint256 weight) {
@@ -148,52 +148,48 @@ contract AdminVoting is DelegatedOps, SystemStart {
             proposal.canExecuteAfter < block.timestamp &&
             proposal.canExecuteAfter + MAX_TIME_TO_EXECUTION > block.timestamp);
 
-        return (
-            proposal.week,
-            proposal.createdAt,
-            proposal.currentWeight,
-            proposal.requiredWeight,
-            proposal.canExecuteAfter,
-            proposal.processed,
-            canExecute,
-            payload
-        );
+        week = proposal.week;
+        createdAt = proposal.createdAt;
+        currentWeight = proposal.currentWeight;
+        requiredWeight = proposal.requiredWeight;
+        canExecuteAfter = proposal.canExecuteAfter;
+        executed = proposal.processed;
     }
 
     // helper functions added because getProposalData returns a lot of fields
     // which can result in "stack too deep" errors
-    function getProposalWeek(uint256 id) external view returns(uint256) {
-        return proposalData[id].week;
+    function getProposalWeek(uint256 id) external view returns(uint256 week) {
+        week = proposalData[id].week;
     }
-    function getProposalCreatedAt(uint256 id) external view returns(uint32) {
-        return proposalData[id].createdAt;
+    function getProposalCreatedAt(uint256 id) external view returns(uint32 createdAt) {
+        createdAt = proposalData[id].createdAt;
     }
-    function getProposalCurrentWeight(uint256 id) external view returns(uint256) {
-        return proposalData[id].currentWeight;
+    function getProposalCurrentWeight(uint256 id) external view returns(uint256 currentWeight) {
+        currentWeight = proposalData[id].currentWeight;
     }
-    function getProposalRequiredWeight(uint256 id) external view returns(uint256) {
-        return proposalData[id].requiredWeight;
+    function getProposalRequiredWeight(uint256 id) external view returns(uint256 requiredWeight) {
+        requiredWeight = proposalData[id].requiredWeight;
     }
-    function getProposalCanExecuteAfter(uint256 id) external view returns(uint32) {
-        return proposalData[id].canExecuteAfter;
+    function getProposalCanExecuteAfter(uint256 id) external view returns(uint32 canExecAfter) {
+        canExecAfter = proposalData[id].canExecuteAfter;
     }
-    function getProposalProcessed(uint256 id) external view returns(bool) {
-        return proposalData[id].processed;
+    function getProposalProcessed(uint256 id) external view returns(bool processed) {
+        processed = proposalData[id].processed;
     }
-    function getProposalCanExecute(uint256 id) external view returns(bool) {
+    function getProposalCanExecute(uint256 id) external view returns(bool canExec) {
         Proposal memory proposal = proposalData[id];
 
-        return (!proposal.processed &&
-                proposal.currentWeight >= proposal.requiredWeight &&
-                proposal.canExecuteAfter < block.timestamp &&
-                proposal.canExecuteAfter + MAX_TIME_TO_EXECUTION > block.timestamp);
+        canExec = (!proposal.processed &&
+                   proposal.currentWeight >= proposal.requiredWeight &&
+                   proposal.canExecuteAfter < block.timestamp &&
+                   proposal.canExecuteAfter + MAX_TIME_TO_EXECUTION > block.timestamp);
     }
-    function getProposalPayload(uint256 id) external view returns(Action[] memory) {
-        return proposalPayloads[id];
+    function getProposalPayload(uint256 id) external view returns(Action[] memory payload) {
+        payload = proposalPayloads[id];
     }
-    function getProposalPassed(uint256 id) external view returns(bool) {
+    function getProposalPassed(uint256 id) external view returns(bool passed) {
         Proposal memory proposal = proposalData[id];
-        return proposal.currentWeight >= proposal.requiredWeight;
+        passed = proposal.currentWeight >= proposal.requiredWeight;
     }
 
 
@@ -413,7 +409,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         @dev Only callable via a passing proposal that includes a call
              to this contract and function within it's payload
      */
-    function setMinCreateProposalPct(uint256 pct) external returns (bool) {
+    function setMinCreateProposalPct(uint256 pct) external returns (bool success) {
         // enforce this function can only be called by this contract
         require(msg.sender == address(this), "Only callable via proposal");
 
@@ -424,7 +420,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         minCreateProposalPct = pct;
 
         emit ProposalCreationMinPctSet(pct);
-        return true;
+        success = true;
     }
 
     /**
@@ -433,7 +429,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         @dev Only callable via a passing proposal that includes a call
              to this contract and function within it's payload
      */
-    function setPassingPct(uint256 pct) external returns (bool) {
+    function setPassingPct(uint256 pct) external returns (bool success) {
         // enforce this function can only be called by this contract
         require(msg.sender == address(this), "Only callable via proposal");
 
@@ -444,7 +440,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         passingPct = pct;
 
         emit ProposalPassingPctSet(pct);
-        return true;
+        success = true;
     }
 
     /**
@@ -455,7 +451,7 @@ contract AdminVoting is DelegatedOps, SystemStart {
         babelCore.acceptTransferOwnership();
     }
 
-    function _containsSetGuardianPayload(uint256 payloadLength, Action[] memory payload) internal pure returns (bool) {
+    function _containsSetGuardianPayload(uint256 payloadLength, Action[] memory payload) internal pure returns (bool success) {
         // iterate through every payload
         for(uint256 i; i<payloadLength; i++) {
             bytes memory data = payload[i].data;
@@ -470,6 +466,6 @@ contract AdminVoting is DelegatedOps, SystemStart {
             if(sig == IBabelCore.setGuardian.selector) return true;
         }
 
-        return false;
+        // if reach here return default false
     }
 }

--- a/contracts/dao/AirdropDistributor.sol
+++ b/contracts/dao/AirdropDistributor.sol
@@ -72,12 +72,12 @@ contract AirdropDistributor is Ownable {
         emit SweepUnclaimedTokens(amount);
     }
 
-    function isClaimed(uint256 index) public view returns (bool) {
+    function isClaimed(uint256 index) public view returns (bool output) {
         uint256 claimedWordIndex = index / 256;
         uint256 claimedBitIndex = index % 256;
         uint256 claimedWord = claimedBitMap[claimedWordIndex];
         uint256 mask = (1 << claimedBitIndex);
-        return claimedWord & mask == mask;
+        output = claimedWord & mask == mask;
     }
 
     function _setClaimed(uint256 index) private {
@@ -126,11 +126,11 @@ contract AirdropDistributor is Ownable {
         @notice Set a claim callback contract
         @dev When set, claims directed to the caller trigger a callback to this address
      */
-    function setClaimCallback(address _callback) external returns (bool) {
+    function setClaimCallback(address _callback) external returns (bool success) {
         claimCallback[msg.sender] = _callback;
 
         emit SetClaimCallback(msg.sender, _callback);
 
-        return true;
+        success = true;
     }
 }

--- a/contracts/dao/BabelToken.sol
+++ b/contracts/dao/BabelToken.sol
@@ -53,23 +53,23 @@ contract BabelToken is OFT, IERC2612 {
         vault = _vault;
     }
 
-    function mintToVault(uint256 _totalSupply) external returns (bool) {
+    function mintToVault(uint256 _totalSupply) external returns (bool success) {
         require(msg.sender == vault);
         require(maxTotalSupply == 0);
 
         _mint(vault, _totalSupply);
         maxTotalSupply = _totalSupply;
 
-        return true;
+        success = true;
     }
 
     // --- EIP 2612 functionality ---
 
-    function domainSeparator() public view override returns (bytes32) {
+    function domainSeparator() public view override returns (bytes32 output) {
         if (block.chainid == _CACHED_CHAIN_ID) {
-            return _CACHED_DOMAIN_SEPARATOR;
+            output = _CACHED_DOMAIN_SEPARATOR;
         } else {
-            return _buildDomainSeparator(_TYPE_HASH, _HASHED_NAME, _HASHED_VERSION);
+            output = _buildDomainSeparator(_TYPE_HASH, _HASHED_NAME, _HASHED_VERSION);
         }
     }
 
@@ -95,21 +95,21 @@ contract BabelToken is OFT, IERC2612 {
         _approve(owner, spender, amount);
     }
 
-    function nonces(address owner) external view override returns (uint256) {
+    function nonces(address owner) external view override returns (uint256 nonce) {
         // FOR EIP 2612
-        return _nonces[owner];
+        nonce = _nonces[owner];
     }
 
-    function transferToLocker(address sender, uint256 amount) external returns (bool) {
+    function transferToLocker(address sender, uint256 amount) external returns (bool success) {
         require(msg.sender == locker, "Not locker");
         _transfer(sender, locker, amount);
-        return true;
+        success = true;
     }
 
     // --- Internal operations ---
 
-    function _buildDomainSeparator(bytes32 typeHash, bytes32 name_, bytes32 version_) private view returns (bytes32) {
-        return keccak256(abi.encode(typeHash, name_, version_, block.chainid, address(this)));
+    function _buildDomainSeparator(bytes32 typeHash, bytes32 name_, bytes32 version_) private view returns (bytes32 output) {
+        output = keccak256(abi.encode(typeHash, name_, version_, block.chainid, address(this)));
     }
 
     function _beforeTokenTransfer(address, address to, uint256) internal virtual override {

--- a/contracts/dao/EmissionSchedule.sol
+++ b/contracts/dao/EmissionSchedule.sol
@@ -50,8 +50,8 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
         emit LockParametersSet(_initialLockWeeks, _lockDecayWeeks);
     }
 
-    function getWeeklyPctSchedule() external view returns (uint64[2][] memory) {
-        return scheduledWeeklyPct;
+    function getWeeklyPctSchedule() external view returns (uint64[2][] memory output) {
+        output = scheduledWeeklyPct;
     }
 
     /**
@@ -60,15 +60,15 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
         @param _schedule Dynamic array of (week, weeklyPct) ordered by week descending.
                          Each `week` indicates the number of weeks after the current week.
      */
-    function setWeeklyPctSchedule(uint64[2][] calldata _schedule) external onlyOwner returns (bool) {
+    function setWeeklyPctSchedule(uint64[2][] calldata _schedule) external onlyOwner returns (bool success) {
         _setWeeklyPctSchedule(_schedule);
-        return true;
+        success = true;
     }
 
     /**
         @notice Set the number of lock weeks and rate at which lock weeks decay
      */
-    function setLockParameters(uint64 _lockWeeks, uint64 _lockDecayWeeks) external onlyOwner returns (bool) {
+    function setLockParameters(uint64 _lockWeeks, uint64 _lockDecayWeeks) external onlyOwner returns (bool success) {
         // enforce max number of lock weeks
         require(_lockWeeks <= MAX_LOCK_WEEKS, "Cannot exceed MAX_LOCK_WEEKS");
 
@@ -80,7 +80,7 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
         lockDecayWeeks = _lockDecayWeeks;
 
         emit LockParametersSet(_lockWeeks, _lockDecayWeeks);
-        return true;
+        success = true;
     }
 
     function getReceiverWeeklyEmissions(

--- a/contracts/dao/EmissionSchedule.sol
+++ b/contracts/dao/EmissionSchedule.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {IEmissionSchedule, IIncentiveVoting, IBabelVault} from "../interfaces/IEmissionSchedule.sol";
 import {BabelOwnable} from "../dependencies/BabelOwnable.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
+import {BIMA_100_PCT} from "../dependencies/Constants.sol";
 
 /**
     @title Babel Emission Schedule
@@ -13,8 +14,6 @@ import {SystemStart} from "../dependencies/SystemStart.sol";
             but should not reach zero for a Very Long Time.
  */
 contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
-    // number representing 100% in `weeklyPct`
-    uint256 constant MAX_PCT = 10000;
     uint256 public constant MAX_LOCK_WEEKS = 52;
 
     IIncentiveVoting public immutable voter;
@@ -149,7 +148,7 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
         }
 
         // calculate the weekly emissions as a percentage of the unallocated supply
-        amount = (unallocatedTotal * pct) / MAX_PCT;
+        amount = (unallocatedTotal * pct) / BIMA_100_PCT;
     }
 
     function _setWeeklyPctSchedule(uint64[2][] memory _scheduledWeeklyPct) internal {
@@ -179,7 +178,7 @@ contract EmissionSchedule is IEmissionSchedule, BabelOwnable, SystemStart {
                 _scheduledWeeklyPct[i][0] = uint64(week + currentWeek);
 
                 // enforce maximum 100% distribution of remaining supply 
-                require(_scheduledWeeklyPct[i][1] <= MAX_PCT, "Cannot exceed MAX_PCT");
+                require(_scheduledWeeklyPct[i][1] <= BIMA_100_PCT, "Cannot exceed MAX_PCT");
             }
 
             // enforce week inputs as number of weeks from current week (ie > 0)

--- a/contracts/dao/InterimAdmin.sol
+++ b/contracts/dao/InterimAdmin.sol
@@ -64,8 +64,8 @@ contract InterimAdmin is Ownable {
     /**
         @notice The total number of votes created
      */
-    function getProposalCount() external view returns (uint256) {
-        return proposalData.length;
+    function getProposalCount() external view returns (uint256 count) {
+        count = proposalData.length;
     }
 
     /**
@@ -84,7 +84,9 @@ contract InterimAdmin is Ownable {
             proposal.canExecuteAfter < block.timestamp &&
             proposal.canExecuteAfter + MAX_TIME_TO_EXECUTION > block.timestamp);
 
-        return (proposal.createdAt, proposal.canExecuteAfter, proposal.processed, canExecute, payload);
+        createdAt = proposal.createdAt;
+        canExecuteAfter = proposal.canExecuteAfter;
+        executed = proposal.processed;
     }
 
     /**
@@ -210,13 +212,13 @@ contract InterimAdmin is Ownable {
         babelCore.commitTransferOwnership(adminVoting);
     }
 
-    function _isSetGuardianPayload(Action calldata action) internal pure returns (bool) {
+    function _isSetGuardianPayload(Action calldata action) internal pure returns (bool output) {
         bytes memory data = action.data;
         // Extract the call sig from payload data
         bytes4 sig;
         assembly {
             sig := mload(add(data, 0x20))
         }
-        return sig == IBabelCore.setGuardian.selector;
+        output = sig == IBabelCore.setGuardian.selector;
     }
 }

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -6,12 +6,9 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {BabelOwnable} from "../dependencies/BabelOwnable.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
 import {IBabelVault, ITokenLocker, IBabelToken, IIncentiveVoting, IEmissionSchedule, IBoostDelegate, IBoostCalculator, IRewards, IERC20} from "../interfaces/IVault.sol";
+import {IEmissionReceiver} from "../interfaces/IEmissionReceiver.sol";
 
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
-
-interface IEmissionReceiver {
-    function notifyRegisteredId(uint256[] calldata assignedIds) external returns (bool);
-}
 
 /**
     @title Babel Vault

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -300,9 +300,11 @@ contract BabelVault is IBabelVault, BabelOwnable, SystemStart {
             weeklyEmissions[week] = SafeCast.toUint128(weeklyAmount);
 
             // update working data
-            unallocated = unallocated - weeklyAmount;
-            
-            emit UnallocatedSupplyReduced(weeklyAmount, unallocated);
+            if(weeklyAmount > 0) {
+                unallocated = unallocated - weeklyAmount;
+                
+                emit UnallocatedSupplyReduced(weeklyAmount, unallocated);
+            }
         }
 
         // update storage

--- a/contracts/dependencies/BabelBase.sol
+++ b/contracts/dependencies/BabelBase.sol
@@ -24,17 +24,17 @@ contract BabelBase is IBabelBase {
     // --- Gas compensation functions ---
 
     // Returns the composite debt (drawn debt + gas compensation) of a trove, for the purpose of ICR calculation
-    function _getCompositeDebt(uint256 _debt) internal view returns (uint256) {
-        return _debt + DEBT_GAS_COMPENSATION;
+    function _getCompositeDebt(uint256 _debt) internal view returns (uint256 result) {
+        result = _debt + DEBT_GAS_COMPENSATION;
     }
 
-    function _getNetDebt(uint256 _debt) internal view returns (uint256) {
-        return _debt - DEBT_GAS_COMPENSATION;
+    function _getNetDebt(uint256 _debt) internal view returns (uint256 result) {
+        result = _debt - DEBT_GAS_COMPENSATION;
     }
 
     // Return the amount of collateral to be drawn from a trove's collateral and sent as gas compensation.
-    function _getCollGasCompensation(uint256 _entireColl) internal pure returns (uint256) {
-        return _entireColl / PERCENT_DIVISOR;
+    function _getCollGasCompensation(uint256 _entireColl) internal pure returns (uint256 result) {
+        result = _entireColl / PERCENT_DIVISOR;
     }
 
     function _requireUserAcceptsFee(uint256 _fee, uint256 _amount, uint256 _maxFeePercentage) internal pure {

--- a/contracts/dependencies/BabelBase.sol
+++ b/contracts/dependencies/BabelBase.sol
@@ -2,14 +2,13 @@
 pragma solidity 0.8.19;
 
 import {IBabelBase} from "../interfaces/IBabelBase.sol";
+import {BIMA_DECIMAL_PRECISION} from "./Constants.sol";
 
 /*
  * Base contract for TroveManager, BorrowerOperations and StabilityPool. Contains global system constants and
  * common functions.
  */
 contract BabelBase is IBabelBase {
-    uint256 public constant DECIMAL_PRECISION = 1e18;
-
     // Critical system collateral ratio. If the system's total collateral ratio (TCR) falls below the CCR, Recovery Mode is triggered.
     uint256 public constant CCR = 2.25e18; // 225%
 
@@ -39,7 +38,7 @@ contract BabelBase is IBabelBase {
     }
 
     function _requireUserAcceptsFee(uint256 _fee, uint256 _amount, uint256 _maxFeePercentage) internal pure {
-        uint256 feePercentage = (_fee * DECIMAL_PRECISION) / _amount;
+        uint256 feePercentage = (_fee * BIMA_DECIMAL_PRECISION) / _amount;
         require(feePercentage <= _maxFeePercentage, "Fee exceeded provided maximum");
     }
 }

--- a/contracts/dependencies/BabelBase.sol
+++ b/contracts/dependencies/BabelBase.sol
@@ -9,7 +9,9 @@ import {BIMA_DECIMAL_PRECISION} from "./Constants.sol";
  * common functions.
  */
 contract BabelBase is IBabelBase {
-    // Critical system collateral ratio. If the system's total collateral ratio (TCR) falls below the CCR, Recovery Mode is triggered.
+    // Critical Collateral Ratio
+    // If the system's total collateral ratio (TCR) falls
+    // below the CCR, Recovery Mode is triggered
     uint256 public constant CCR = 2.25e18; // 225%
 
     // Amount of debt to be locked in gas pool on opening troves

--- a/contracts/dependencies/BabelMath.sol
+++ b/contracts/dependencies/BabelMath.sol
@@ -15,12 +15,12 @@ library BabelMath {
      */
     uint256 internal constant NICR_PRECISION = 1e20;
 
-    function _min(uint256 _a, uint256 _b) internal pure returns (uint256) {
-        return (_a < _b) ? _a : _b;
+    function _min(uint256 _a, uint256 _b) internal pure returns (uint256 result) {
+        result = (_a < _b) ? _a : _b;
     }
 
-    function _max(uint256 _a, uint256 _b) internal pure returns (uint256) {
-        return (_a >= _b) ? _a : _b;
+    function _max(uint256 _a, uint256 _b) internal pure returns (uint256 result) {
+        result = (_a >= _b) ? _a : _b;
     }
 
     /*
@@ -54,73 +54,70 @@ library BabelMath {
      * In function 1), the decayed base rate will be 0 for 1000 years or > 1000 years
      * In function 2), the difference in tokens issued at 1000 years and any time > 1000 years, will be negligible
      */
-    function _decPow(uint256 _base, uint256 _minutes) internal pure returns (uint256) {
+    function _decPow(uint256 _base, uint256 _minutes) internal pure returns (uint256 result) {
         if (_minutes > 525600000) {
             _minutes = 525600000;
         } // cap to avoid overflow
 
         if (_minutes == 0) {
-            return DECIMAL_PRECISION;
+            result = DECIMAL_PRECISION;
         }
+        else {
+            uint256 y = DECIMAL_PRECISION;
+            uint256 x = _base;
+            uint256 n = _minutes;
 
-        uint256 y = DECIMAL_PRECISION;
-        uint256 x = _base;
-        uint256 n = _minutes;
-
-        // Exponentiation-by-squaring
-        while (n > 1) {
-            if (n % 2 == 0) {
-                x = decMul(x, x);
-                n = n / 2;
-            } else {
-                // if (n % 2 != 0)
-                y = decMul(x, y);
-                x = decMul(x, x);
-                n = (n - 1) / 2;
+            // Exponentiation-by-squaring
+            while (n > 1) {
+                if (n % 2 == 0) {
+                    x = decMul(x, x);
+                    n = n / 2;
+                } else {
+                    // if (n % 2 != 0)
+                    y = decMul(x, y);
+                    x = decMul(x, x);
+                    n = (n - 1) / 2;
+                }
             }
+
+            result = decMul(x, y);
         }
-
-        return decMul(x, y);
     }
 
-    function _getAbsoluteDifference(uint256 _a, uint256 _b) internal pure returns (uint256) {
-        return (_a >= _b) ? _a - _b : _b - _a;
+    function _getAbsoluteDifference(uint256 _a, uint256 _b) internal pure returns (uint256 result) {
+        result = (_a >= _b) ? _a - _b : _b - _a;
     }
 
-    function _computeNominalCR(uint256 _coll, uint256 _debt) internal pure returns (uint256) {
+    function _computeNominalCR(uint256 _coll, uint256 _debt) internal pure returns (uint256 result) {
         if (_debt > 0) {
-            return (_coll * NICR_PRECISION) / _debt;
+            result = (_coll * NICR_PRECISION) / _debt;
         }
         // Return the maximal value for uint256 if the Trove has a debt of 0. Represents "infinite" CR.
         else {
             // if (_debt == 0)
-            return 2 ** 256 - 1;
+            result = 2 ** 256 - 1;
         }
     }
 
-    function _computeCR(uint256 _coll, uint256 _debt, uint256 _price) internal pure returns (uint256) {
+    function _computeCR(uint256 _coll, uint256 _debt, uint256 _price) internal pure returns (uint256 result) {
         if (_debt > 0) {
-            uint256 newCollRatio = (_coll * _price) / _debt;
-
-            return newCollRatio;
+            result = (_coll * _price) / _debt;
         }
         // Return the maximal value for uint256 if the Trove has a debt of 0. Represents "infinite" CR.
         else {
             // if (_debt == 0)
-            return 2 ** 256 - 1;
+            result = 2 ** 256 - 1;
         }
     }
 
-    function _computeCR(uint256 _coll, uint256 _debt) internal pure returns (uint256) {
+    function _computeCR(uint256 _coll, uint256 _debt) internal pure returns (uint256 result) {
         if (_debt > 0) {
-            uint256 newCollRatio = (_coll) / _debt;
-
-            return newCollRatio;
+            result = (_coll) / _debt;
         }
         // Return the maximal value for uint256 if the Trove has a debt of 0. Represents "infinite" CR.
         else {
             // if (_debt == 0)
-            return 2 ** 256 - 1;
+            result = 2 ** 256 - 1;
         }
     }
 }

--- a/contracts/dependencies/BabelMath.sol
+++ b/contracts/dependencies/BabelMath.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-library BabelMath {
-    uint256 internal constant DECIMAL_PRECISION = 1e18;
+import {BIMA_DECIMAL_PRECISION} from "./Constants.sol";
 
+library BabelMath {
     /* Precision for Nominal ICR (independent of price). Rationale for the value:
      *
      * - Making it “too high” could lead to overflows.
@@ -33,7 +33,7 @@ library BabelMath {
     function decMul(uint256 x, uint256 y) internal pure returns (uint256 decProd) {
         uint256 prod_xy = x * y;
 
-        decProd = (prod_xy + (DECIMAL_PRECISION / 2)) / DECIMAL_PRECISION;
+        decProd = (prod_xy + (BIMA_DECIMAL_PRECISION / 2)) / BIMA_DECIMAL_PRECISION;
     }
 
     /*
@@ -60,10 +60,10 @@ library BabelMath {
         } // cap to avoid overflow
 
         if (_minutes == 0) {
-            result = DECIMAL_PRECISION;
+            result = BIMA_DECIMAL_PRECISION;
         }
         else {
-            uint256 y = DECIMAL_PRECISION;
+            uint256 y = BIMA_DECIMAL_PRECISION;
             uint256 x = _base;
             uint256 n = _minutes;
 

--- a/contracts/dependencies/BabelOwnable.sol
+++ b/contracts/dependencies/BabelOwnable.sol
@@ -21,11 +21,11 @@ contract BabelOwnable is IBabelOwnable {
         _;
     }
 
-    function owner() public view returns (address) {
-        return BABEL_CORE.owner();
+    function owner() public view returns (address result) {
+        result = BABEL_CORE.owner();
     }
 
-    function guardian() public view returns (address) {
-        return BABEL_CORE.guardian();
+    function guardian() public view returns (address result) {
+        result = BABEL_CORE.guardian();
     }
 }

--- a/contracts/dependencies/Constants.sol
+++ b/contracts/dependencies/Constants.sol
@@ -10,3 +10,6 @@ uint256 constant BIMA_DECIMAL_PRECISION = 1e18;
 
 // BIMA's default scale factor
 uint256 constant BIMA_SCALE_FACTOR = 1e9;
+
+// BIMA's default reward duration
+uint256 constant BIMA_REWARD_DURATION = 1 weeks;

--- a/contracts/dependencies/Constants.sol
+++ b/contracts/dependencies/Constants.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// represents 100% in BIMA used in denominator when
+// calculating amounts based on a percentage
+uint256 constant BIMA_100_PCT = 10_000;

--- a/contracts/dependencies/Constants.sol
+++ b/contracts/dependencies/Constants.sol
@@ -7,3 +7,6 @@ uint256 constant BIMA_100_PCT = 10_000;
 
 // BIMA's default decimal precision
 uint256 constant BIMA_DECIMAL_PRECISION = 1e18;
+
+// BIMA's default scale factor
+uint256 constant BIMA_SCALE_FACTOR = 1e9;

--- a/contracts/dependencies/Constants.sol
+++ b/contracts/dependencies/Constants.sol
@@ -4,3 +4,6 @@ pragma solidity 0.8.19;
 // represents 100% in BIMA used in denominator when
 // calculating amounts based on a percentage
 uint256 constant BIMA_100_PCT = 10_000;
+
+// BIMA's default decimal precision
+uint256 constant BIMA_DECIMAL_PRECISION = 1e18;

--- a/contracts/dependencies/SystemStart.sol
+++ b/contracts/dependencies/SystemStart.sol
@@ -16,6 +16,6 @@ contract SystemStart is ISystemStart {
     }
 
     function getWeek() public view returns (uint256 week) {
-        return (block.timestamp - startTime) / 1 weeks;
+        week = (block.timestamp - startTime) / 1 weeks;
     }
 }

--- a/contracts/interfaces/IBabelBase.sol
+++ b/contracts/interfaces/IBabelBase.sol
@@ -2,8 +2,6 @@
 pragma solidity 0.8.19;
 
 interface IBabelBase {
-    function DECIMAL_PRECISION() external returns(uint256);
-
     function CCR() external returns(uint256);
 
     function DEBT_GAS_COMPENSATION() external returns(uint256);

--- a/contracts/interfaces/ICurveProxy.sol
+++ b/contracts/interfaces/ICurveProxy.sol
@@ -39,6 +39,9 @@ interface ICurveProxy {
     }
 
     event CrvFeePctSet(uint256 feePct);
+    event SetVoteManager(address voteManager);
+    event SetDepositManager(address depositManager);
+    event SetPerGaugeApproval(address caller, address gauge);
 
     function approveGaugeDeposit(address gauge, address depositor) external returns (bool);
 

--- a/contracts/interfaces/IEmissionReceiver.sol
+++ b/contracts/interfaces/IEmissionReceiver.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+interface IEmissionReceiver {
+    function notifyRegisteredId(uint256[] calldata assignedIds) external returns (bool);
+}

--- a/contracts/interfaces/IFactory.sol
+++ b/contracts/interfaces/IFactory.sol
@@ -21,6 +21,7 @@ interface IFactory is IBabelOwnable {
     }
 
     event NewDeployment(address collateral, address priceFeed, address troveManager, address sortedTroves);
+    event ImplementationContractsChanged(address newTroveManagerImpl, address newSortedTrovesImpl);
 
     function deployNewInstance(
         address collateral,

--- a/contracts/interfaces/IStabilityPool.sol
+++ b/contracts/interfaces/IStabilityPool.sol
@@ -38,8 +38,6 @@ interface IStabilityPool is IBabelOwnable, ISystemStart {
 
     function P() external view returns (uint256);
 
-    function SCALE_FACTOR() external view returns (uint256);
-
     function SUNSET_DURATION() external view returns (uint128);
 
     function accountDeposits(address) external view returns (uint128 amount, uint128 timestamp);

--- a/contracts/interfaces/IStabilityPool.sol
+++ b/contracts/interfaces/IStabilityPool.sol
@@ -36,8 +36,6 @@ interface IStabilityPool is IBabelOwnable, ISystemStart {
 
     function withdrawFromSP(uint256 _amount) external;
 
-    function DECIMAL_PRECISION() external view returns (uint256);
-
     function P() external view returns (uint256);
 
     function SCALE_FACTOR() external view returns (uint256);

--- a/contracts/interfaces/IStabilityPool.sol
+++ b/contracts/interfaces/IStabilityPool.sol
@@ -60,7 +60,7 @@ interface IStabilityPool is IBabelOwnable, ISystemStart {
 
     function depositSums(address, uint256) external view returns (uint256);
 
-    function emissionId() external view returns (uint256);
+    function SP_EMISSION_ID() external view returns (uint256);
 
     function epochToScaleToG(uint128, uint128) external view returns (uint256);
 

--- a/contracts/interfaces/ITroveManager.sol
+++ b/contracts/interfaces/ITroveManager.sol
@@ -8,9 +8,10 @@ import {IDebtToken} from "./IDebtToken.sol";
 import {IBabelVault} from "./IVault.sol";
 import {IPriceFeed} from "./IPriceFeed.sol";
 import {ISortedTroves} from "./ISortedTroves.sol";
+import {IEmissionReceiver} from "./IEmissionReceiver.sol";
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-interface ITroveManager is IBabelBase, IBabelOwnable, ISystemStart {
+interface ITroveManager is IBabelBase, IBabelOwnable, ISystemStart, IEmissionReceiver {
     event BaseRateUpdated(uint256 _baseRate);
     event CollateralSent(address _to, uint256 _amount);
     event LTermsUpdated(uint256 _L_collateral, uint256 _L_debt);
@@ -75,8 +76,6 @@ interface ITroveManager is IBabelBase, IBabelOwnable, ISystemStart {
     function getEntireSystemBalances() external returns (uint256, uint256, uint256);
 
     function movePendingTroveRewardsToActiveBalances(uint256 _debt, uint256 _collateral) external;
-
-    function notifyRegisteredId(uint256[] calldata _assignedIds) external returns (bool);
 
     function openTrove(
         address _borrower,

--- a/contracts/interfaces/ITroveManager.sol
+++ b/contracts/interfaces/ITroveManager.sol
@@ -28,6 +28,19 @@ interface ITroveManager is IBabelBase, IBabelOwnable, ISystemStart, IEmissionRec
     event TroveIndexUpdated(address _borrower, uint256 _newIndex);
     event TroveSnapshotsUpdated(uint256 _L_collateral, uint256 _L_debt);
     event TroveUpdated(address indexed _borrower, uint256 _debt, uint256 _coll, uint256 _stake, TroveManagerOperation _operation);
+    event Paused();
+    event Unpaused();
+    event SetPriceFeed(address);
+    event StartSunset();
+    event SetParameters(uint256 _minuteDecayFactor,
+                        uint256 _redemptionFeeFloor,
+                        uint256 _maxRedemptionFee,
+                        uint256 _borrowingFeeFloor,
+                        uint256 _maxBorrowingFee,
+                        uint256 _interestRateInBPS,
+                        uint256 _maxSystemDebt,
+                        uint256 _MCR);
+    event CollectedInterest(uint256 amount);
 
     enum Status {
         nonExistent,

--- a/contracts/interfaces/ITroveManager.sol
+++ b/contracts/interfaces/ITroveManager.sol
@@ -225,7 +225,7 @@ interface ITroveManager is IBabelBase, IBabelOwnable, ISystemStart, IEmissionRec
 
     function getTroveStake(address _borrower) external view returns (uint256);
 
-    function getTroveStatus(address _borrower) external view returns (uint256);
+    function getTroveStatus(address _borrower) external view returns (Status);
 
     function getWeekAndDay() external view returns (uint256, uint256);
 

--- a/contracts/staking/Convex/ConvexDepositFactory.sol
+++ b/contracts/staking/Convex/ConvexDepositFactory.sol
@@ -35,7 +35,7 @@ contract ConvexFactory is BabelOwnable {
         emit NewDeployment(pid, depositToken);
     }
 
-    function getDepositToken(uint256 pid) external view returns (address) {
-        return Clones.predictDeterministicAddress(depositTokenImpl, bytes32(pid));
+    function getDepositToken(uint256 pid) external view returns (address addr) {
+        addr = Clones.predictDeterministicAddress(depositTokenImpl, bytes32(pid));
     }
 }

--- a/contracts/staking/Convex/ConvexDepositToken.sol
+++ b/contracts/staking/Convex/ConvexDepositToken.sol
@@ -261,16 +261,20 @@ contract ConvexDepositToken is IEmissionReceiver {
                 integral += (duration * rewardRate[i] * 1e18) / supply;
                 rewardIntegral[i] = integral;
             }
-            uint256 integralFor = rewardIntegralFor[account][i];
-            if (integral > integralFor) {
-                storedPendingReward[account][i] += uint128((balance * (integral - integralFor)) / 1e18);
-                rewardIntegralFor[account][i] = integral;
+
+            if (account != address(0)) {
+                uint256 integralFor = rewardIntegralFor[account][i];
+                if (integral > integralFor) {
+                    storedPendingReward[account][i] += uint128((balance * (integral - integralFor)) / 1e18);
+                    rewardIntegralFor[account][i] = integral;
+                }
             }
         }
     }
 
     function fetchRewards() external {
         require(block.timestamp / 1 weeks >= periodFinish / 1 weeks, "Can only fetch once per week");
+        _updateIntegrals(address(0), 0, totalSupply);
         _fetchRewards();
     }
 

--- a/contracts/staking/Convex/ConvexDepositToken.sol
+++ b/contracts/staking/Convex/ConvexDepositToken.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {ICurveProxy} from "../../interfaces/ICurveProxy.sol";
 import {IBabelVault} from "../../interfaces/IVault.sol";
 import {IEmissionReceiver} from "../../interfaces/IEmissionReceiver.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
 import {BIMA_100_PCT} from "../../dependencies/Constants.sol";
+
+import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 interface IBooster {
     function deposit(uint256 _pid, uint256 _amount, bool _stake) external returns (bool);
@@ -266,7 +268,7 @@ contract ConvexDepositToken is IEmissionReceiver {
             if (account != address(0)) {
                 uint256 integralFor = rewardIntegralFor[account][i];
                 if (integral > integralFor) {
-                    storedPendingReward[account][i] += uint128((balance * (integral - integralFor)) / 1e18);
+                    storedPendingReward[account][i] += SafeCast.toUint128((balance * (integral - integralFor)) / 1e18);
                     rewardIntegralFor[account][i] = integral;
                 }
             }
@@ -294,11 +296,11 @@ contract ConvexDepositToken is IEmissionReceiver {
             crvAmount -= fee;
             CRV.transfer(address(curveProxy), fee);
         }
-        lastCrvBalance = uint128(last + crvAmount);
+        lastCrvBalance = SafeCast.toUint128(last + crvAmount);
 
         last = lastCvxBalance;
         uint256 cvxAmount = CVX.balanceOf(address(this)) - last;
-        lastCvxBalance = uint128(cvxAmount + last);
+        lastCvxBalance = SafeCast.toUint128(cvxAmount + last);
 
         uint256 _periodFinish = periodFinish;
         if (block.timestamp < _periodFinish) {
@@ -308,9 +310,9 @@ contract ConvexDepositToken is IEmissionReceiver {
             cvxAmount += remaining * rewardRate[2];
         }
 
-        rewardRate[0] = uint128(babelAmount / REWARD_DURATION);
-        rewardRate[1] = uint128(crvAmount / REWARD_DURATION);
-        rewardRate[2] = uint128(cvxAmount / REWARD_DURATION);
+        rewardRate[0] = SafeCast.toUint128(babelAmount / REWARD_DURATION);
+        rewardRate[1] = SafeCast.toUint128(crvAmount / REWARD_DURATION);
+        rewardRate[2] = SafeCast.toUint128(cvxAmount / REWARD_DURATION);
 
         lastUpdate = uint32(block.timestamp);
         periodFinish = uint32(block.timestamp + REWARD_DURATION);

--- a/contracts/staking/Convex/ConvexDepositToken.sol
+++ b/contracts/staking/Convex/ConvexDepositToken.sol
@@ -5,7 +5,7 @@ import {ICurveProxy} from "../../interfaces/ICurveProxy.sol";
 import {IBabelVault} from "../../interfaces/IVault.sol";
 import {IEmissionReceiver} from "../../interfaces/IEmissionReceiver.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
-import {BIMA_100_PCT} from "../../dependencies/Constants.sol";
+import {BIMA_100_PCT, BIMA_REWARD_DURATION} from "../../dependencies/Constants.sol";
 
 import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
@@ -77,8 +77,6 @@ contract ConvexDepositToken is IEmissionReceiver {
 
     mapping(address => uint256[3]) public rewardIntegralFor;
     mapping(address => uint128[3]) private storedPendingReward;
-
-    uint256 constant REWARD_DURATION = 1 weeks;
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
@@ -310,11 +308,11 @@ contract ConvexDepositToken is IEmissionReceiver {
             cvxAmount += remaining * rewardRate[2];
         }
 
-        rewardRate[0] = SafeCast.toUint128(babelAmount / REWARD_DURATION);
-        rewardRate[1] = SafeCast.toUint128(crvAmount / REWARD_DURATION);
-        rewardRate[2] = SafeCast.toUint128(cvxAmount / REWARD_DURATION);
+        rewardRate[0] = SafeCast.toUint128(babelAmount / BIMA_REWARD_DURATION);
+        rewardRate[1] = SafeCast.toUint128(crvAmount / BIMA_REWARD_DURATION);
+        rewardRate[2] = SafeCast.toUint128(cvxAmount / BIMA_REWARD_DURATION);
 
         lastUpdate = uint32(block.timestamp);
-        periodFinish = uint32(block.timestamp + REWARD_DURATION);
+        periodFinish = uint32(block.timestamp + BIMA_REWARD_DURATION);
     }
 }

--- a/contracts/staking/Convex/ConvexDepositToken.sol
+++ b/contracts/staking/Convex/ConvexDepositToken.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {ICurveProxy} from "../../interfaces/ICurveProxy.sol";
 import {IBabelVault} from "../../interfaces/IVault.sol";
+import {IEmissionReceiver} from "../../interfaces/IEmissionReceiver.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
 
 interface IBooster {
@@ -35,7 +36,7 @@ interface IConvexStash {
             Tokens are minted by depositing Curve LP tokens, and burned to receive the LP
             tokens back. Holders may claim BABEL emissions on top of the earned CRV and CVX.
  */
-contract ConvexDepositToken {
+contract ConvexDepositToken is IEmissionReceiver {
     IERC20 public immutable BABEL;
     IERC20 public immutable CRV;
     IERC20 public immutable CVX;

--- a/contracts/staking/Convex/ConvexDepositToken.sol
+++ b/contracts/staking/Convex/ConvexDepositToken.sol
@@ -6,6 +6,7 @@ import {ICurveProxy} from "../../interfaces/ICurveProxy.sol";
 import {IBabelVault} from "../../interfaces/IVault.sol";
 import {IEmissionReceiver} from "../../interfaces/IEmissionReceiver.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
+import {BIMA_100_PCT} from "../../dependencies/Constants.sol";
 
 interface IBooster {
     function deposit(uint256 _pid, uint256 _amount, bool _stake) external returns (bool);
@@ -288,7 +289,7 @@ contract ConvexDepositToken is IEmissionReceiver {
         uint256 last = lastCrvBalance;
         uint256 crvAmount = CRV.balanceOf(address(this)) - last;
         // apply CRV fee and send fee tokens to curveProxy
-        uint256 fee = (crvAmount * curveProxy.crvFeePct()) / 10000;
+        uint256 fee = (crvAmount * curveProxy.crvFeePct()) / BIMA_100_PCT;
         if (fee > 0) {
             crvAmount -= fee;
             CRV.transfer(address(curveProxy), fee);

--- a/contracts/staking/Curve/CurveDepositFactory.sol
+++ b/contracts/staking/Curve/CurveDepositFactory.sol
@@ -39,7 +39,7 @@ contract CurveFactory is BabelOwnable {
         emit NewDeployment(gauge, depositToken);
     }
 
-    function getDepositToken(address gauge) external view returns (address) {
-        return Clones.predictDeterministicAddress(depositTokenImpl, bytes32(bytes20(gauge)));
+    function getDepositToken(address gauge) external view returns (address addr) {
+        addr = Clones.predictDeterministicAddress(depositTokenImpl, bytes32(bytes20(gauge)));
     }
 }

--- a/contracts/staking/Curve/CurveDepositToken.sol
+++ b/contracts/staking/Curve/CurveDepositToken.sol
@@ -6,6 +6,7 @@ import {IBabelVault} from "../../interfaces/IVault.sol";
 import {ILiquidityGauge} from "../../interfaces/ILiquidityGauge.sol";
 import {IEmissionReceiver} from "../../interfaces/IEmissionReceiver.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
+import {BIMA_REWARD_DURATION} from "../../dependencies/Constants.sol";
 
 import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
@@ -44,8 +45,6 @@ contract CurveDepositToken is IEmissionReceiver {
 
     mapping(address => uint256[2]) public rewardIntegralFor;
     mapping(address => uint128[2]) private storedPendingReward;
-
-    uint256 constant REWARD_DURATION = 1 weeks;
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event Approval(address indexed owner, address indexed spender, uint256 value);
@@ -246,10 +245,10 @@ contract CurveDepositToken is IEmissionReceiver {
             babelAmount += remaining * rewardRate[0];
             crvAmount += remaining * rewardRate[1];
         }
-        rewardRate[0] = SafeCast.toUint128(babelAmount / REWARD_DURATION);
-        rewardRate[1] = SafeCast.toUint128(crvAmount / REWARD_DURATION);
+        rewardRate[0] = SafeCast.toUint128(babelAmount / BIMA_REWARD_DURATION);
+        rewardRate[1] = SafeCast.toUint128(crvAmount / BIMA_REWARD_DURATION);
 
         lastUpdate = uint32(block.timestamp);
-        periodFinish = uint32(block.timestamp + REWARD_DURATION);
+        periodFinish = uint32(block.timestamp + BIMA_REWARD_DURATION);
     }
 }

--- a/contracts/staking/Curve/CurveDepositToken.sol
+++ b/contracts/staking/Curve/CurveDepositToken.sol
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.19;
 
-import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {ICurveProxy} from "../../interfaces/ICurveProxy.sol";
 import {IBabelVault} from "../../interfaces/IVault.sol";
 import {ILiquidityGauge} from "../../interfaces/ILiquidityGauge.sol";
 import {IEmissionReceiver} from "../../interfaces/IEmissionReceiver.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
+
+import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
 /**
     @title Babel Curve Deposit Wrapper
@@ -214,7 +216,7 @@ contract CurveDepositToken is IEmissionReceiver {
             if (account != address(0)) {
                 uint256 integralFor = rewardIntegralFor[account][i];
                 if (integral > integralFor) {
-                    storedPendingReward[account][i] += uint128((balance * (integral - integralFor)) / 1e18);
+                    storedPendingReward[account][i] += SafeCast.toUint128((balance * (integral - integralFor)) / 1e18);
                     rewardIntegralFor[account][i] = integral;
                 }
             }
@@ -244,8 +246,8 @@ contract CurveDepositToken is IEmissionReceiver {
             babelAmount += remaining * rewardRate[0];
             crvAmount += remaining * rewardRate[1];
         }
-        rewardRate[0] = uint128(babelAmount / REWARD_DURATION);
-        rewardRate[1] = uint128(crvAmount / REWARD_DURATION);
+        rewardRate[0] = SafeCast.toUint128(babelAmount / REWARD_DURATION);
+        rewardRate[1] = SafeCast.toUint128(crvAmount / REWARD_DURATION);
 
         lastUpdate = uint32(block.timestamp);
         periodFinish = uint32(block.timestamp + REWARD_DURATION);

--- a/contracts/staking/Curve/CurveDepositToken.sol
+++ b/contracts/staking/Curve/CurveDepositToken.sol
@@ -210,16 +210,20 @@ contract CurveDepositToken is IEmissionReceiver {
                 integral += (duration * rewardRate[i] * 1e18) / supply;
                 rewardIntegral[i] = integral;
             }
-            uint256 integralFor = rewardIntegralFor[account][i];
-            if (integral > integralFor) {
-                storedPendingReward[account][i] += uint128((balance * (integral - integralFor)) / 1e18);
-                rewardIntegralFor[account][i] = integral;
+
+            if (account != address(0)) {
+                uint256 integralFor = rewardIntegralFor[account][i];
+                if (integral > integralFor) {
+                    storedPendingReward[account][i] += uint128((balance * (integral - integralFor)) / 1e18);
+                    rewardIntegralFor[account][i] = integral;
+                }
             }
         }
     }
 
     function fetchRewards() external {
         require(block.timestamp / 1 weeks >= periodFinish / 1 weeks, "Can only fetch once per week");
+        _updateIntegrals(address(0), 0, totalSupply);
         _fetchRewards();
     }
 

--- a/contracts/staking/Curve/CurveDepositToken.sol
+++ b/contracts/staking/Curve/CurveDepositToken.sol
@@ -5,6 +5,7 @@ import {IERC20Metadata, IERC20} from "@openzeppelin/contracts/token/ERC20/extens
 import {ICurveProxy} from "../../interfaces/ICurveProxy.sol";
 import {IBabelVault} from "../../interfaces/IVault.sol";
 import {ILiquidityGauge} from "../../interfaces/ILiquidityGauge.sol";
+import {IEmissionReceiver} from "../../interfaces/IEmissionReceiver.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
 
 /**
@@ -14,7 +15,7 @@ import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
             burned to receive the LP tokens back. Holders may claim BABEL emissions
             on top of the earned CRV.
  */
-contract CurveDepositToken {
+contract CurveDepositToken is IEmissionReceiver {
     IERC20 public immutable BABEL;
     IERC20 public immutable CRV;
     ICurveProxy public immutable curveProxy;

--- a/contracts/staking/Curve/CurveProxy.sol
+++ b/contracts/staking/Curve/CurveProxy.sol
@@ -5,6 +5,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ILiquidityGauge} from "../../interfaces/ILiquidityGauge.sol";
 import {BabelOwnable} from "../../dependencies/BabelOwnable.sol";
+import {BIMA_100_PCT} from "../../dependencies/Constants.sol";
 
 import {ICurveProxy, IGaugeController, IERC20, IMinter, IFeeDistributor, IVotingEscrow, IAragon} from "../../interfaces/ICurveProxy.sol";
 
@@ -30,7 +31,7 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
     uint256 constant WEEK = 604800;
     uint256 constant MAX_LOCK_DURATION = 4 * 365 * 86400; // 4 years
 
-    uint64 public crvFeePct; // fee as a pct out of 10000
+    uint64 public crvFeePct; // fee as a pct out of BIMA_100_PCT
     uint64 public unlockTime;
 
     // the vote manager is approved to call voting-related functions
@@ -102,7 +103,7 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
         @dev CRV earned as fees is periodically added to the contract's locked position
      */
     function setCrvFeePct(uint64 _feePct) external onlyOwner returns (bool success) {
-        require(_feePct <= 10000, "Invalid setting");
+        require(_feePct <= BIMA_100_PCT, "Invalid setting");
         crvFeePct = _feePct;
         emit CrvFeePctSet(_feePct);
         success = true;
@@ -165,7 +166,7 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
         amount = CRV.balanceOf(address(this)) - initial;
 
         // apply fee prior to transfer
-        uint256 fee = (amount * crvFeePct) / 10000;
+        uint256 fee = (amount * crvFeePct) / BIMA_100_PCT;
         amount -= fee;
 
         CRV.transfer(receiver, amount);

--- a/contracts/staking/Curve/CurveProxy.sol
+++ b/contracts/staking/Curve/CurveProxy.sol
@@ -89,41 +89,41 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
         address target,
         bytes4[] memory selectors,
         bool permitted
-    ) external onlyOwner returns (bool) {
+    ) external onlyOwner returns (bool success) {
         mapping(bytes4 => bool) storage _executePermission = executePermissions[caller][target];
         for (uint256 i; i < selectors.length; i++) {
             _executePermission[selectors[i]] = permitted;
         }
-        return true;
+        success = true;
     }
 
     /**
         @notice Set the fee percent taken on all CRV earned through this contract
         @dev CRV earned as fees is periodically added to the contract's locked position
      */
-    function setCrvFeePct(uint64 _feePct) external onlyOwner returns (bool) {
+    function setCrvFeePct(uint64 _feePct) external onlyOwner returns (bool success) {
         require(_feePct <= 10000, "Invalid setting");
         crvFeePct = _feePct;
         emit CrvFeePctSet(_feePct);
-        return true;
+        success = true;
     }
 
-    function setVoteManager(address _voteManager) external onlyOwner returns (bool) {
+    function setVoteManager(address _voteManager) external onlyOwner returns (bool success) {
         voteManager = _voteManager;
 
-        return true;
+        success = true;
     }
 
-    function setDepositManager(address _depositManager) external onlyOwner returns (bool) {
+    function setDepositManager(address _depositManager) external onlyOwner returns (bool success) {
         depositManager = _depositManager;
 
-        return true;
+        success = true;
     }
 
-    function setPerGaugeApproval(address caller, address gauge) external onlyDepositManager returns (bool) {
+    function setPerGaugeApproval(address caller, address gauge) external onlyDepositManager returns (bool success) {
         perGaugeApproval[caller] = gauge;
 
-        return true;
+        success = true;
     }
 
     /**
@@ -131,13 +131,11 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
                 and transfer the fees onward to the fee receiver
         @dev This method is intentionally left unguarded
      */
-    function claimFees() external returns (uint256) {
+    function claimFees() external returns (uint256 amount) {
         feeDistributor.claim();
-        uint256 amount = feeToken.balanceOf(address(this));
+        amount = feeToken.balanceOf(address(this));
 
         feeToken.transfer(BABEL_CORE.feeReceiver(), amount);
-
-        return amount;
     }
 
     /**
@@ -145,13 +143,13 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
                 the unlock time to the maximum possible
         @dev This method is intentionally left unguarded
      */
-    function lockCRV() external returns (bool) {
+    function lockCRV() external returns (bool success) {
         uint256 maxUnlock = ((block.timestamp / WEEK) * WEEK) + MAX_LOCK_DURATION;
         uint256 amount = CRV.balanceOf(address(this));
 
         _updateLock(amount, unlockTime, maxUnlock);
 
-        return true;
+        success = true;
     }
 
     /**
@@ -159,12 +157,12 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
         @dev Once per week, also locks any CRV balance within the contract and extends the lock duration
         @param gauge Address of the gauge to mint CRV for
         @param receiver Address to send the minted CRV to
-        @return uint256 Amount of CRV send to the receiver (after the fee)
+        @return amount uint256 Amount of CRV send to the receiver (after the fee)
      */
-    function mintCRV(address gauge, address receiver) external onlyApprovedGauge(gauge) returns (uint256) {
+    function mintCRV(address gauge, address receiver) external onlyApprovedGauge(gauge) returns (uint256 amount) {
         uint256 initial = CRV.balanceOf(address(this));
         minter.mint(gauge);
-        uint256 amount = CRV.balanceOf(address(this)) - initial;
+        amount = CRV.balanceOf(address(this)) - initial;
 
         // apply fee prior to transfer
         uint256 fee = (amount * crvFeePct) / 10000;
@@ -178,48 +176,46 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
         if (unlock < maxUnlock) {
             _updateLock(initial + fee, unlock, maxUnlock);
         }
-
-        return amount;
     }
 
     /**
         @notice Submit one or more gauge weight votes
      */
-    function voteForGaugeWeights(GaugeWeightVote[] calldata votes) external ownerOrVoteManager returns (bool) {
+    function voteForGaugeWeights(GaugeWeightVote[] calldata votes) external ownerOrVoteManager returns (bool success) {
         for (uint256 i; i < votes.length; i++) {
             gaugeController.vote_for_gauge_weights(votes[i].gauge, votes[i].weight);
         }
 
-        return true;
+        success = true;
     }
 
     /**
         @notice Submit a vote within the Curve DAO
      */
-    function voteInCurveDao(IAragon aragon, uint256 id, bool support) external ownerOrVoteManager returns (bool) {
+    function voteInCurveDao(IAragon aragon, uint256 id, bool support) external ownerOrVoteManager returns (bool success) {
         aragon.vote(id, support, false);
 
-        return true;
+        success = true;
     }
 
     /**
         @notice Approve a 3rd-party caller to deposit into a specific gauge
         @dev Only required for some older Curve gauges
      */
-    function approveGaugeDeposit(address gauge, address depositor) external onlyApprovedGauge(gauge) returns (bool) {
+    function approveGaugeDeposit(address gauge, address depositor) external onlyApprovedGauge(gauge) returns (bool success) {
         ILiquidityGauge(gauge).set_approve_deposit(depositor, true);
 
-        return true;
+        success = true;
     }
 
     /**
         @notice Set the default receiver for extra rewards on a specific gauge
         @dev Only works on some gauge versions
      */
-    function setGaugeRewardsReceiver(address gauge, address receiver) external onlyApprovedGauge(gauge) returns (bool) {
+    function setGaugeRewardsReceiver(address gauge, address receiver) external onlyApprovedGauge(gauge) returns (bool success) {
         ILiquidityGauge(gauge).set_rewards_receiver(receiver);
 
-        return true;
+        success = true;
     }
 
     /**
@@ -235,11 +231,11 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
         IERC20 lpToken,
         uint256 amount,
         address receiver
-    ) external onlyApprovedGauge(gauge) returns (bool) {
+    ) external onlyApprovedGauge(gauge) returns (bool success) {
         ILiquidityGauge(gauge).withdraw(amount);
         lpToken.transfer(receiver, amount);
 
-        return true;
+        success = true;
     }
 
     /**
@@ -249,12 +245,12 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
     function transferTokens(
         address receiver,
         TokenBalance[] calldata balances
-    ) external onlyDepositManager returns (bool) {
+    ) external onlyDepositManager returns (bool success) {
         for (uint256 i; i < balances.length; i++) {
             balances[i].token.safeTransfer(receiver, balances[i].amount);
         }
 
-        return true;
+        success = true;
     }
 
     /**
@@ -262,12 +258,12 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
         @dev Callable via the owner, or if explicit permission is given
              to the caller for this target and function selector
      */
-    function execute(address target, bytes calldata data) external returns (bytes memory) {
+    function execute(address target, bytes calldata data) external returns (bytes memory retData) {
         if (msg.sender != owner()) {
             bytes4 selector = bytes4(data[:4]);
             require(executePermissions[msg.sender][target][selector], "Not permitted");
         }
-        return target.functionCall(data);
+        retData = target.functionCall(data);
     }
 
     function _updateLock(uint256 amount, uint256 unlock, uint256 maxUnlock) internal {

--- a/contracts/staking/Curve/CurveProxy.sol
+++ b/contracts/staking/Curve/CurveProxy.sol
@@ -87,7 +87,7 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
     function setExecutePermissions(
         address caller,
         address target,
-        bytes4[] memory selectors,
+        bytes4[] calldata selectors,
         bool permitted
     ) external onlyOwner returns (bool success) {
         mapping(bytes4 => bool) storage _executePermission = executePermissions[caller][target];

--- a/contracts/staking/Curve/CurveProxy.sol
+++ b/contracts/staking/Curve/CurveProxy.sol
@@ -111,18 +111,21 @@ contract CurveProxy is ICurveProxy, BabelOwnable {
 
     function setVoteManager(address _voteManager) external onlyOwner returns (bool success) {
         voteManager = _voteManager;
+        emit SetVoteManager(_voteManager);
 
         success = true;
     }
 
     function setDepositManager(address _depositManager) external onlyOwner returns (bool success) {
         depositManager = _depositManager;
+        emit SetDepositManager(_depositManager);
 
         success = true;
     }
 
     function setPerGaugeApproval(address caller, address gauge) external onlyDepositManager returns (bool success) {
         perGaugeApproval[caller] = gauge;
+        emit SetPerGaugeApproval(caller, gauge);
 
         success = true;
     }

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -103,7 +103,7 @@ contract TestSetup is Test {
     uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1e18;
     address internal constant ZERO_ADDRESS = address(0);
 
-    uint256 internal constant INIT_BS_GRACE_WEEKS = 2;
+    uint256 internal constant INIT_BS_GRACE_WEEKS = 5;
     uint64 internal constant INIT_ES_LOCK_WEEKS = 4;
     uint64 internal constant INIT_ES_LOCK_DECAY_WEEKS = 1;
     uint64 internal constant INIT_ES_WEEKLY_PCT = 2500; // 25%

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -10,7 +10,7 @@ import {IDebtToken} from "../../contracts/interfaces/IDebtToken.sol";
 import {IStabilityPool} from "../../contracts/interfaces/IStabilityPool.sol";
 import {IBorrowerOperations} from "../../contracts/interfaces/IBorrowerOperations.sol";
 import {ILiquidationManager} from "../../contracts/interfaces/ILiquidationManager.sol";
-import {IBabelVault, IRewards} from "../../contracts/interfaces/IVault.sol";
+import {IBabelVault, IRewards, IBoostDelegate} from "../../contracts/interfaces/IVault.sol";
 import {IBabelToken} from "../../contracts/interfaces/IBabelToken.sol";
 import {IIncentiveVoting} from "../../contracts/interfaces/IIncentiveVoting.sol";
 import {ITokenLocker} from "../../contracts/interfaces/ITokenLocker.sol";
@@ -469,5 +469,22 @@ contract MockEmissionReceiver is IEmissionReceiver, IRewards {
 
     function claimableReward(address) external view returns (uint256 amount) {
         amount = reward;
+    }
+}
+
+contract MockBoostDelegate is IBoostDelegate {
+    uint256 feePct;
+
+    function setFeePct(uint256 newFeePct) external {
+        feePct = newFeePct;
+    }
+
+    function getFeePct(address, address, uint256, uint256, uint256) external view returns (uint256 val) {
+        val = feePct;
+    }
+
+    function delegatedBoostCallback(address , address , uint256 , uint256 ,
+                                    uint256 , uint256 , uint256) external pure returns (bool success) {
+        success = true;
     }
 }

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -10,7 +10,7 @@ import {IDebtToken} from "../../contracts/interfaces/IDebtToken.sol";
 import {IStabilityPool} from "../../contracts/interfaces/IStabilityPool.sol";
 import {IBorrowerOperations} from "../../contracts/interfaces/IBorrowerOperations.sol";
 import {ILiquidationManager} from "../../contracts/interfaces/ILiquidationManager.sol";
-import {IBabelVault} from "../../contracts/interfaces/IVault.sol";
+import {IBabelVault, IRewards} from "../../contracts/interfaces/IVault.sol";
 import {IBabelToken} from "../../contracts/interfaces/IBabelToken.sol";
 import {IIncentiveVoting} from "../../contracts/interfaces/IIncentiveVoting.sol";
 import {ITokenLocker} from "../../contracts/interfaces/ITokenLocker.sol";
@@ -438,9 +438,10 @@ contract TestSetup is Test {
     }
 }
 
-contract MockEmissionReceiver is IEmissionReceiver {
+contract MockEmissionReceiver is IEmissionReceiver, IRewards {
     bool public notifyRegisteredIdCalled;
     uint256[] public lastAssignedIds;
+    uint256 public reward;
 
     function notifyRegisteredId(uint256[] calldata assignedIds) external returns (bool success) {
         notifyRegisteredIdCalled = true;
@@ -456,5 +457,17 @@ contract MockEmissionReceiver is IEmissionReceiver {
     function assertNotifyRegisteredIdCalled(uint256 expectedCount) external view {
         require(notifyRegisteredIdCalled, "notifyRegisteredId was not called");
         require(lastAssignedIds.length == expectedCount, "Unexpected number of assigned IDs");
+    }
+
+    function setReward(uint256 newReward) external {
+        reward = newReward;
+    }
+
+    function vaultClaimReward(address, address) external view returns (uint256 amount) {
+        amount = reward;
+    }
+
+    function claimableReward(address) external view returns (uint256 amount) {
+        amount = reward;
     }
 }

--- a/test/foundry/core/BabelCoreTest.t.sol
+++ b/test/foundry/core/BabelCoreTest.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup} from "../TestSetup.sol";
+
+contract BabelCoreTest is TestSetup {
+
+    function test_setPaused_guardianCanPauseNotUnpause() external {
+        vm.prank(users.guardian);
+        babelCore.setPaused(true);
+
+        assertTrue(babelCore.paused());
+
+        vm.expectRevert("Unauthorized");
+        vm.prank(users.guardian);
+        babelCore.setPaused(false);
+    }
+
+    function test_setPaused_ownerCanPauseUnpause() external {
+        vm.prank(users.owner);
+        babelCore.setPaused(true);
+
+        assertTrue(babelCore.paused());
+
+        vm.prank(users.owner);
+        babelCore.setPaused(false);
+
+        assertFalse(babelCore.paused());
+    }
+
+    function test_setPaused_failNormalUser() external {
+        vm.expectRevert("Unauthorized");
+        vm.prank(users.user1);
+        babelCore.setPaused(true);
+
+        vm.expectRevert("Unauthorized");
+        vm.prank(users.user1);
+        babelCore.setPaused(false);
+    }
+}

--- a/test/foundry/core/StabilityPoolTest.t.sol
+++ b/test/foundry/core/StabilityPoolTest.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup} from "../TestSetup.sol";
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract StabilityPoolTest is TestSetup {
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // only 1 collateral token exists due to base setup
+        assertEq(stabilityPool.getNumCollateralTokens(), 1);
+    }
+
+    function test_enableCollateral() public returns(IERC20 newCollateral) {
+        // add 1 new collateral
+        newCollateral = IERC20(address(0x1234));
+
+        vm.prank(address(factory));
+        stabilityPool.enableCollateral(newCollateral);
+
+        // verify storage
+        assertEq(stabilityPool.getNumCollateralTokens(), 2);
+        assertEq(stabilityPool.indexByCollateral(newCollateral), 2);
+        assertEq(address(stabilityPool.collateralTokens(1)), address(newCollateral));
+    }
+
+    function test_startCollateralSunset() public returns(IERC20 sunsetCollateral) {
+        // first add new collateral
+        sunsetCollateral = test_enableCollateral();
+
+        // get sunset queue before sunset
+        (, uint16 nextSunsetIndexKeyPre) = stabilityPool.getSunsetQueueKeys();
+
+        // then sunset it
+        vm.prank(users.owner);
+        stabilityPool.startCollateralSunset(sunsetCollateral);
+
+        // verify storage
+        assertEq(stabilityPool.getNumCollateralTokens(), 2);
+        assertEq(stabilityPool.indexByCollateral(sunsetCollateral), 0);
+        assertEq(address(stabilityPool.collateralTokens(1)), address(sunsetCollateral));
+        
+        (uint128 idx, uint128 expiry) = stabilityPool.getSunsetIndexes(nextSunsetIndexKeyPre);
+        assertEq(idx, 1);
+        assertEq(expiry, block.timestamp + stabilityPool.SUNSET_DURATION());
+
+        (, uint16 nextSunsetIndexKeyPost) = stabilityPool.getSunsetQueueKeys();
+        assertEq(nextSunsetIndexKeyPost, nextSunsetIndexKeyPre + 1);
+    }
+
+    function test_enableCollateral_overwriteSunsetCollateral() external {
+        // first add new collateral then sunset it
+        IERC20 sunsetCollateral = test_startCollateralSunset();
+
+        // then add another new collateral
+        IERC20 newCollateral1 = IERC20(address(0x12345));
+        vm.prank(address(factory));
+        stabilityPool.enableCollateral(newCollateral1);
+
+        // verify storage
+        assertEq(stabilityPool.getNumCollateralTokens(), 3);
+        assertEq(stabilityPool.indexByCollateral(newCollateral1), 3);
+        assertEq(address(stabilityPool.collateralTokens(1)), address(sunsetCollateral));
+        assertEq(address(stabilityPool.collateralTokens(2)), address(newCollateral1));
+
+        // warp time past the sunset expiry
+        vm.warp(block.timestamp + stabilityPool.SUNSET_DURATION() + 1);
+
+        // get sunset queue before overwrite
+        (uint16 firstSunsetIndexKeyPre, ) = stabilityPool.getSunsetQueueKeys();
+
+        // add 1 more new collateral; this should over-write the sunsetted one
+        IERC20 newCollateral2 = IERC20(address(0x123456));
+
+        vm.prank(address(factory));
+        stabilityPool.enableCollateral(newCollateral2);
+
+        // verify that this over-wrote the sunsetted collateral
+        assertEq(stabilityPool.getNumCollateralTokens(), 3);
+        assertEq(stabilityPool.indexByCollateral(newCollateral2), 2);
+        assertEq(stabilityPool.indexByCollateral(sunsetCollateral), 0);
+        assertEq(address(stabilityPool.collateralTokens(1)), address(newCollateral2));
+        assertEq(address(stabilityPool.collateralTokens(2)), address(newCollateral1));
+
+        (uint128 idx, uint128 expiry) = stabilityPool.getSunsetIndexes(firstSunsetIndexKeyPre);
+        assertEq(idx, 0);
+        assertEq(expiry, 0);
+
+        (uint16 firstSunsetIndexKeyPost, ) = stabilityPool.getSunsetQueueKeys();
+        assertEq(firstSunsetIndexKeyPost, firstSunsetIndexKeyPre + 1);
+    }
+
+}

--- a/test/foundry/core/StabilityPoolTest.t.sol
+++ b/test/foundry/core/StabilityPoolTest.t.sol
@@ -28,6 +28,20 @@ contract StabilityPoolTest is TestSetup {
         assertEq(address(stabilityPool.collateralTokens(1)), address(newCollateral));
     }
 
+    function test_enableCollateral_failToAddMoreThanMaxCollaterals() external {
+        for(uint160 i=1; i<=255; i++) {
+            address newCollateral = address(i);
+
+            vm.prank(address(factory));
+            stabilityPool.enableCollateral(IERC20(newCollateral));
+        }
+
+        // try to add one more
+        vm.expectRevert("Maximum collateral length reached");
+        vm.prank(address(factory));
+        stabilityPool.enableCollateral(IERC20(address(uint160(256))));
+    }
+
     function test_startCollateralSunset() public returns(IERC20 sunsetCollateral) {
         // first add new collateral
         sunsetCollateral = test_enableCollateral();
@@ -93,5 +107,4 @@ contract StabilityPoolTest is TestSetup {
         (uint16 firstSunsetIndexKeyPost, ) = stabilityPool.getSunsetQueueKeys();
         assertEq(firstSunsetIndexKeyPost, firstSunsetIndexKeyPre + 1);
     }
-
 }

--- a/test/foundry/dao/AdminVotingTest.t.sol
+++ b/test/foundry/dao/AdminVotingTest.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 import {AdminVoting} from "../../../contracts/dao/AdminVoting.sol";
 import {IBabelCore} from "../../../contracts/interfaces/IBabelCore.sol";
+import {BIMA_100_PCT} from "../../../contracts/dependencies/Constants.sol";
 
 // test setup
 import {TestSetup, IBabelVault} from "../TestSetup.sol";
@@ -107,7 +108,7 @@ contract AdminVotingTest is TestSetup {
         // verify requiredWeight calculated using correct passing percent
         assertEq(adminVoting.getProposalRequiredWeight(proposalId), 
                  (tokenLocker.getTotalWeightAt(proposalWeek) * proposalPassingPct) /
-                 adminVoting.MAX_PCT());
+                 BIMA_100_PCT);
         // verify proposal details stored correctly
         assertEq(adminVoting.getProposalWeek(proposalId), proposalWeek);
         assertEq(adminVoting.getProposalCreatedAt(proposalId), block.timestamp);
@@ -208,7 +209,7 @@ contract AdminVotingTest is TestSetup {
         // verify requiredWeight calculated using standard passing percent
         assertEq(adminVoting.getProposalRequiredWeight(1), 
                  (tokenLocker.getTotalWeightAt(adminVoting.getWeek()-1) * adminVoting.passingPct()) /
-                 adminVoting.MAX_PCT());
+                 BIMA_100_PCT);
     }
 
     // helper function to successfully cancel a proposal


### PR DESCRIPTION
* Fix for H-2 The fetchRewards function in CurveDepositToken and ConvexDepositToken causes a loss of accrued rewards
* Fix for L-9 StabilityPool::claimCollateralGains should accrue depositor gains before claiming
* Fix for L-10 StabilityPool::claimableReward incorrectly returns lower than actual value as it doesn't include storedPendingReward
* Fix for L-11 StabilityPool user functions panic revert if more than 256 collaterals are enabled
* Fix for I-13 Consolidate 10000, MAX_FEE_PCT and MAX_PCT used in many contracts into one shared constant
* Fix for I-14 Consolidate DECIMAL_PRECISION used in three contracts into one shared constant
* Fix for I-15 Consolidate SCALE_FACTOR used in two contracts into one shared constant
* Fix for I-16 Consolidate REWARD_DURATION used in four contracts into one shared constant
* Fix for I-17 Use ITroveManager::Status enum types instead of casting to uint256
* lots more using named returns (should be finished now)
* use `calldata` instead of `memory` for external function array inputs
* don't cache `calldata` input array length
* CurveDepositToken, ConvexDepositToken and ITroveManager now implement the IEmissionReceiver interface to enable compile-time checks
* more tests