### PR TITLE
Fix H-3, H-4, M-5, L-12, L-13, L-14 plus more tests

### DIFF
--- a/contracts/core/BorrowerOperations.sol
+++ b/contracts/core/BorrowerOperations.sol
@@ -80,6 +80,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
     function _setMinNetDebt(uint256 _minNetDebt) internal {
         require(_minNetDebt > 0);
         minNetDebt = _minNetDebt;
+        emit SetMinDetDebt(_minNetDebt);
     }
 
     function configureCollateral(ITroveManager troveManager, IERC20 collateralToken) external {
@@ -366,7 +367,7 @@ contract BorrowerOperations is IBorrowerOperations, BabelBase, BabelOwnable, Del
             _requireAtLeastMinNetDebt(_getNetDebt(vars.debt) - vars.netDebtChange);
         }
 
-        // If we are incrasing collateral, send tokens to the trove manager prior to adjusting the trove
+        // If we are increasing collateral, send tokens to the trove manager prior to adjusting the trove
         if (vars.isCollIncrease) collateralToken.safeTransferFrom(msg.sender, address(troveManager), vars.collChange);
 
         (vars.newColl, vars.newDebt, vars.stake) = troveManager.updateTroveFromAdjustment(

--- a/contracts/core/LiquidationManager.sol
+++ b/contracts/core/LiquidationManager.sol
@@ -165,7 +165,12 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         troveManagerValues.MCR = troveManager.MCR();
         uint256 debtInStabPool = stabilityPoolCached.getTotalDebtTokenDeposits();
 
-        while (trovesRemaining > 0 && troveCount >= 1) {
+        // liquidation is always prevented when there is only 1 trove by design
+        // the protocol operators should have their own trove open with each TroveManager
+        // instance with minimal debt and highest CR which enables all other troves
+        // to be liquidated and ensures their trove will always be the last one during sunsetting
+        // see comment in TroveManager::_resetState
+        while (trovesRemaining > 0 && troveCount > 1) {
             address account = sortedTrovesCached.getLast();
             uint256 ICR = troveManager.getCurrentICR(account, troveManagerValues.price);
             if (ICR > maxICR) {
@@ -193,7 +198,6 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             }
         }
 
-        // note: did not enable troveCount >= 1 here as later code looks for other troves
         if (trovesRemaining > 0 && !troveManagerValues.sunsetting && troveCount > 1) {
             (uint256 entireSystemColl, uint256 entireSystemDebt) = borrowerOperations.getGlobalSystemBalances();
             entireSystemColl -= totals.totalCollToSendToSP * troveManagerValues.price;
@@ -299,7 +303,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         uint256 length = _troveArray.length;
         uint256 troveIter;
 
-        while (troveIter < length && troveCount >= 1) {
+        while (troveIter < length && troveCount > 1) {
             // first iteration round, when all liquidated troves have ICR < MCR we do not need to track TCR
             address account = _troveArray[troveIter];
 
@@ -329,13 +333,13 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             }
         }
 
-        if (troveIter < length && troveCount >= 1) {
+        if (troveIter < length && troveCount > 1) {
             // second iteration round, if we receive a trove with ICR > MCR and need to track TCR
             (uint256 entireSystemColl, uint256 entireSystemDebt) = borrowerOperations.getGlobalSystemBalances();
             entireSystemColl -= totals.totalCollToSendToSP * troveManagerValues.price;
             entireSystemDebt -= totals.totalDebtToOffset;
 
-            while (troveIter < length && troveCount >= 1) {
+            while (troveIter < length && troveCount > 1) {
                 address account = _troveArray[troveIter];
                 uint256 ICR = troveManager.getCurrentICR(account, troveManagerValues.price);
                 unchecked {

--- a/contracts/core/LiquidationManager.sol
+++ b/contracts/core/LiquidationManager.sol
@@ -128,7 +128,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
      */
     function liquidate(ITroveManager troveManager, address borrower) external {
         require(troveManager.getTroveStatus(borrower) == ITroveManager.Status.active,
-                "TroveManager: Trove does not exist or is closed");
+                "LiquidationManager: Trove does not exist or is closed");
 
         address[] memory borrowers = new address[](1);
         borrowers[0] = borrower;
@@ -225,7 +225,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             }
         }
 
-        require(totals.totalDebtInSequence > 0, "TroveManager: nothing to liquidate");
+        require(totals.totalDebtInSequence > 0, "LiquidationManager: nothing to liquidate");
         if (totals.totalDebtToOffset > 0 || totals.totalCollToSendToSP > 0) {
             // Move liquidated collateral and Debt to the appropriate pools
             stabilityPoolCached.offset(
@@ -267,7 +267,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
      */
     function batchLiquidateTroves(ITroveManager troveManager, address[] memory _troveArray) public {
         require(_enabledTroveManagers[troveManager], "TroveManager not approved");
-        require(_troveArray.length != 0, "TroveManager: Calldata address array must not be empty");
+        require(_troveArray.length != 0, "LiquidationManager: _troveArray array must not be empty");
         troveManager.updateBalances();
 
         LiquidationValues memory singleLiquidation;
@@ -355,7 +355,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             }
         }
 
-        require(totals.totalDebtInSequence > 0, "TroveManager: nothing to liquidate");
+        require(totals.totalDebtInSequence > 0, "LiquidationManager: nothing to liquidate");
 
         if (totals.totalDebtToOffset > 0 || totals.totalCollToSendToSP > 0) {
             // Move liquidated collateral and Debt to the appropriate pools

--- a/contracts/core/LiquidationManager.sol
+++ b/contracts/core/LiquidationManager.sol
@@ -119,6 +119,10 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         _enabledTroveManagers[_troveManager] = true;
     }
 
+    function isTroveManagerEnabled(ITroveManager troveManager) external view returns(bool isEnabled) {
+        isEnabled = _enabledTroveManagers[troveManager];
+    }
+
     // --- Trove Liquidation functions ---
 
     /**
@@ -182,23 +186,28 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
                 debtInStabPool -= singleLiquidation.debtToOffset;
                 _applyLiquidationValuesToTotals(totals, singleLiquidation);
             } else break; // break if the loop reaches a Trove with ICR >= MCR
+
             unchecked {
                 --trovesRemaining;
                 --troveCount;
             }
         }
+
         if (trovesRemaining > 0 && !troveManagerValues.sunsetting && troveCount > 1) {
             (uint256 entireSystemColl, uint256 entireSystemDebt) = borrowerOperations.getGlobalSystemBalances();
             entireSystemColl -= totals.totalCollToSendToSP * troveManagerValues.price;
             entireSystemDebt -= totals.totalDebtToOffset;
             address nextAccount = sortedTrovesCached.getLast();
             ITroveManager _troveManager = troveManager; //stack too deep workaround
+
             while (trovesRemaining > 0 && troveCount > 1) {
                 uint256 ICR = troveManager.getCurrentICR(nextAccount, troveManagerValues.price);
                 if (ICR > maxICR) break;
+
                 unchecked {
                     --trovesRemaining;
                 }
+
                 address account = nextAccount;
                 nextAccount = sortedTrovesCached.getPrev(account);
 
@@ -212,13 +221,17 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
                     troveManagerValues.MCR,
                     troveManagerValues.price
                 );
+
                 if (singleLiquidation.debtToOffset == 0) continue;
+
                 debtInStabPool -= singleLiquidation.debtToOffset;
                 entireSystemColl -=
                     (singleLiquidation.collToSendToSP + singleLiquidation.collSurplus) *
                     troveManagerValues.price;
                 entireSystemDebt -= singleLiquidation.debtToOffset;
+
                 _applyLiquidationValuesToTotals(totals, singleLiquidation);
+
                 unchecked {
                     --troveCount;
                 }
@@ -233,12 +246,14 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
                 totals.totalDebtToOffset,
                 totals.totalCollToSendToSP
             );
+
             troveManager.decreaseDebtAndSendCollateral(
                 address(stabilityPoolCached),
                 totals.totalDebtToOffset,
                 totals.totalCollToSendToSP
             );
         }
+
         troveManager.finalizeLiquidation(
             msg.sender,
             totals.totalDebtToRedistribute,
@@ -282,6 +297,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         uint256 troveCount = troveManager.getTroveOwnersCount();
         uint256 length = _troveArray.length;
         uint256 troveIter;
+
         while (troveIter < length && troveCount > 1) {
             // first iteration round, when all liquidated troves have ICR < MCR we do not need to track TCR
             address account = _troveArray[troveIter];
@@ -290,7 +306,8 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             uint256 ICR = troveManager.getCurrentICR(account, troveManagerValues.price);
             if (ICR <= _100pct) {
                 singleLiquidation = _liquidateWithoutSP(troveManager, account);
-            } else if (ICR < troveManagerValues.MCR) {
+            }
+            else if (ICR < troveManagerValues.MCR) {
                 singleLiquidation = _liquidateNormalMode(
                     troveManager,
                     account,
@@ -298,10 +315,12 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
                     troveManagerValues.sunsetting
                 );
                 debtInStabPool -= singleLiquidation.debtToOffset;
-            } else {
+            }
+            else {
                 // As soon as we find a trove with ICR >= MCR we need to start tracking the global TCR with the next loop
                 break;
             }
+
             _applyLiquidationValuesToTotals(totals, singleLiquidation);
             unchecked {
                 ++troveIter;
@@ -314,22 +333,26 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             (uint256 entireSystemColl, uint256 entireSystemDebt) = borrowerOperations.getGlobalSystemBalances();
             entireSystemColl -= totals.totalCollToSendToSP * troveManagerValues.price;
             entireSystemDebt -= totals.totalDebtToOffset;
+
             while (troveIter < length && troveCount > 1) {
                 address account = _troveArray[troveIter];
                 uint256 ICR = troveManager.getCurrentICR(account, troveManagerValues.price);
                 unchecked {
                     ++troveIter;
                 }
+                
                 if (ICR <= _100pct) {
                     singleLiquidation = _liquidateWithoutSP(troveManager, account);
-                } else if (ICR < troveManagerValues.MCR) {
+                }
+                else if (ICR < troveManagerValues.MCR) {
                     singleLiquidation = _liquidateNormalMode(
                         troveManager,
                         account,
                         debtInStabPool,
                         troveManagerValues.sunsetting
                     );
-                } else {
+                }
+                else {
                     if (troveManagerValues.sunsetting) continue;
                     uint256 TCR = BabelMath._computeCR(entireSystemColl, entireSystemDebt);
                     if (TCR >= CCR || ICR >= TCR) continue;
@@ -348,6 +371,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
                     (singleLiquidation.collToSendToSP + singleLiquidation.collSurplus) *
                     troveManagerValues.price;
                 entireSystemDebt -= singleLiquidation.debtToOffset;
+
                 _applyLiquidationValuesToTotals(totals, singleLiquidation);
                 unchecked {
                     --troveCount;
@@ -400,7 +424,6 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
     ) internal returns (LiquidationValues memory singleLiquidation) {
         uint256 pendingDebtReward;
         uint256 pendingCollReward;
-
         (
             singleLiquidation.entireTroveDebt,
             singleLiquidation.entireTroveColl,
@@ -454,7 +477,6 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         uint256 entireTroveColl;
         uint256 pendingDebtReward;
         uint256 pendingCollReward;
-
         (entireTroveDebt, entireTroveColl, pendingDebtReward, pendingCollReward) = troveManager.getEntireDebtAndColl(
             _borrower
         );
@@ -503,7 +525,6 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
     ) internal returns (LiquidationValues memory singleLiquidation) {
         uint256 pendingDebtReward;
         uint256 pendingCollReward;
-
         (
             singleLiquidation.entireTroveDebt,
             singleLiquidation.entireTroveColl,

--- a/contracts/core/LiquidationManager.sol
+++ b/contracts/core/LiquidationManager.sol
@@ -165,7 +165,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         troveManagerValues.MCR = troveManager.MCR();
         uint256 debtInStabPool = stabilityPoolCached.getTotalDebtTokenDeposits();
 
-        while (trovesRemaining > 0 && troveCount > 1) {
+        while (trovesRemaining > 0 && troveCount >= 1) {
             address account = sortedTrovesCached.getLast();
             uint256 ICR = troveManager.getCurrentICR(account, troveManagerValues.price);
             if (ICR > maxICR) {
@@ -193,6 +193,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             }
         }
 
+        // note: did not enable troveCount >= 1 here as later code looks for other troves
         if (trovesRemaining > 0 && !troveManagerValues.sunsetting && troveCount > 1) {
             (uint256 entireSystemColl, uint256 entireSystemDebt) = borrowerOperations.getGlobalSystemBalances();
             entireSystemColl -= totals.totalCollToSendToSP * troveManagerValues.price;
@@ -298,7 +299,7 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
         uint256 length = _troveArray.length;
         uint256 troveIter;
 
-        while (troveIter < length && troveCount > 1) {
+        while (troveIter < length && troveCount >= 1) {
             // first iteration round, when all liquidated troves have ICR < MCR we do not need to track TCR
             address account = _troveArray[troveIter];
 
@@ -328,13 +329,13 @@ contract LiquidationManager is ILiquidationManager, BabelBase {
             }
         }
 
-        if (troveIter < length && troveCount > 1) {
+        if (troveIter < length && troveCount >= 1) {
             // second iteration round, if we receive a trove with ICR > MCR and need to track TCR
             (uint256 entireSystemColl, uint256 entireSystemDebt) = borrowerOperations.getGlobalSystemBalances();
             entireSystemColl -= totals.totalCollToSendToSP * troveManagerValues.price;
             entireSystemDebt -= totals.totalDebtToOffset;
 
-            while (troveIter < length && troveCount > 1) {
+            while (troveIter < length && troveCount >= 1) {
                 address account = _troveArray[troveIter];
                 uint256 ICR = troveManager.getCurrentICR(account, troveManagerValues.price);
                 unchecked {

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -1379,11 +1379,8 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         uint256 debtNumerator = (_debt * BIMA_DECIMAL_PRECISION) + lastDebtError_Redistribution;
         uint256 totalStakesCached = totalStakes;
 
-        // if there is only 1 trove open and that is being liquidated, prevent
-        // a panic during liquidation due to divide by zero
-        if(totalStakesCached == 0) {
-            totalStakesCached = 1;
-        }
+        // note: liquidation is prevented when there is only 1 Trove so
+        // totalStakesCached always > 0, see comment in LiquidationManager::liquidateTroves
 
         // Get the per-unit-staked terms
         uint256 collateralRewardPerUnitStaked = collateralNumerator / totalStakesCached;

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -1378,6 +1378,13 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         uint256 collateralNumerator = (_coll * BIMA_DECIMAL_PRECISION) + lastCollateralError_Redistribution;
         uint256 debtNumerator = (_debt * BIMA_DECIMAL_PRECISION) + lastDebtError_Redistribution;
         uint256 totalStakesCached = totalStakes;
+
+        // if there is only 1 trove open and that is being liquidated, prevent
+        // a panic during liquidation due to divide by zero
+        if(totalStakesCached == 0) {
+            totalStakesCached = 1;
+        }
+
         // Get the per-unit-staked terms
         uint256 collateralRewardPerUnitStaked = collateralNumerator / totalStakesCached;
         uint256 debtRewardPerUnitStaked = debtNumerator / totalStakesCached;

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -1190,7 +1190,7 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
     }
 
     function _updateMintVolume(address account, uint256 initialAmount) internal {
-        uint32 amount = uint32(initialAmount / VOLUME_MULTIPLIER);
+        uint32 amount = SafeCast.toUint32(initialAmount / VOLUME_MULTIPLIER);
         (uint256 week, uint256 day) = getWeekAndDay();
         totalMints[week][day] += amount;
 

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -452,15 +452,17 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         coll = t.coll;
 
         (pendingCollateralReward, pendingDebtReward) = getPendingCollAndDebtRewards(_borrower);
+
         // Accrued trove interest for correct liquidation values. This assumes the index to be updated.
         uint256 troveInterestIndex = t.activeInterestIndex;
+
         if (troveInterestIndex > 0) {
             (uint256 currentIndex, ) = _calculateInterestIndex();
             debt = (debt * currentIndex) / troveInterestIndex;
         }
 
-        debt = debt + pendingDebtReward;
-        coll = coll + pendingCollateralReward;
+        debt += pendingDebtReward;
+        coll += pendingCollateralReward;
     }
 
     // includes defaulted collateral
@@ -1313,16 +1315,16 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         _updateIntegralForAccount(_borrower, debtBefore, rewardIntegral);
     }
 
-    function movePendingTroveRewardsToActiveBalances(uint256 _debt, uint256 _collateral) external {
+    function movePendingTroveRewardsToActiveBalances(uint256 _debtRewards, uint256 _collateralRewards) external {
         _requireCallerIsLM();
-        _movePendingTroveRewardsToActiveBalance(_debt, _collateral);
+        _movePendingTroveRewardsToActiveBalance(_debtRewards, _collateralRewards);
     }
 
-    function _movePendingTroveRewardsToActiveBalance(uint256 _debt, uint256 _collateral) internal {
-        defaultedDebt -= _debt;
-        totalActiveDebt += _debt;
-        defaultedCollateral -= _collateral;
-        totalActiveCollateral += _collateral;
+    function _movePendingTroveRewardsToActiveBalance(uint256 _debtRewards, uint256 _collateralRewards) internal {
+        defaultedDebt -= _debtRewards;
+        totalActiveDebt += _debtRewards;
+        defaultedCollateral -= _collateralRewards;
+        totalActiveCollateral += _collateralRewards;
     }
 
     function addCollateralSurplus(address borrower, uint256 collSurplus) external {

--- a/contracts/dao/AdminVoting.sol
+++ b/contracts/dao/AdminVoting.sol
@@ -5,6 +5,7 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {DelegatedOps} from "../dependencies/DelegatedOps.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
 import {BIMA_100_PCT} from "../dependencies/Constants.sol";
+import {BabelMath} from "../dependencies/BabelMath.sol";
 import {ITokenLocker} from "../interfaces/ITokenLocker.sol";
 import {IBabelCore} from "../interfaces/IBabelCore.sol";
 
@@ -227,8 +228,10 @@ contract AdminVoting is DelegatedOps, SystemStart {
             // prevent changing guardians during bootstrap period
             require(block.timestamp > startTime + BOOTSTRAP_PERIOD, "Cannot change guardian during bootstrap");
 
-            // enforce 50.1% majority for setGuardian proposals
-            proposalPassPct = SET_GUARDIAN_PASSING_PCT;
+            // enforce 50.1% majority for setGuardian proposals; if the default
+            // passing percent is greater than the hard-coded setGuardian percent
+            // then use that instead
+            proposalPassPct = BabelMath._max(SET_GUARDIAN_PASSING_PCT, passingPct);
         }
         // otherwise for ordinary proposals enforce standard configured passing %
         else proposalPassPct = passingPct;

--- a/contracts/dao/IncentiveVoting.sol
+++ b/contracts/dao/IncentiveVoting.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {DelegatedOps} from "../dependencies/DelegatedOps.sol";
 import {SystemStart} from "../dependencies/SystemStart.sol";
 import {IIncentiveVoting, ITokenLocker} from "../interfaces/IIncentiveVoting.sol";
+import {IBabelVault} from "../interfaces/IVault.sol";
 
 import {SafeCast} from "@openzeppelin/contracts/utils/math/SafeCast.sol";
 
@@ -613,6 +614,9 @@ contract IncentiveVoting is IIncentiveVoting, DelegatedOps, SystemStart {
         // iterate through votes input, cheaper to not
         // cache length since calldata
         for (uint256 i; i < votes.length; i++) {
+            // prevent voting for disabled receivers
+            require(IBabelVault(vault).isReceiverActive(votes[i].id), "Can't vote for disabled receivers - clearVote first");
+
             // record each vote
             storedVotes[offset + i] = [SafeCast.toUint16(votes[i].id),
                                         SafeCast.toUint16(votes[i].points)];

--- a/contracts/dao/TokenLocker.sol
+++ b/contracts/dao/TokenLocker.sol
@@ -1097,6 +1097,12 @@ contract TokenLocker is ITokenLocker, BabelOwnable, SystemStart {
                     accountWeeklyUnlocks[msg.sender][systemWeek] -= SafeCast.toUint32(lockReduceAmount);
                     totalWeeklyUnlocks[systemWeek] -= SafeCast.toUint32(lockReduceAmount);
 
+                    // if after dust handling user has no remaining tokens locked
+                    // then reset the bitfield
+                    if (accountWeeklyUnlocks[msg.sender][systemWeek] == 0) {
+                        bitfield = bitfield & ~(uint256(1) << (systemWeek % 256));
+                    }
+
                     // nothing remaining to be withdrawn
                     remaining = 0;
                 }

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -324,8 +324,13 @@ contract BabelVault is IBabelVault, BabelOwnable, SystemStart {
         // cache receiver data from storage
         Receiver memory receiver = idToReceiver[id];
 
-        // only account linked to receiver can call this function
-        require(receiver.account == msg.sender, "Not receiver account");
+        // if receiver is active, then only account linked to receiver
+        // can call this function
+        if(receiver.isActive) {
+            require(receiver.account == msg.sender, "Not receiver account");
+        }
+        // otherwise anyone can call this function - required so that tokens
+        // are not permanently lost for disabled receivers
 
         // get current system week
         uint256 currentWeek = getWeek();

--- a/contracts/dao/Vault.sol
+++ b/contracts/dao/Vault.sol
@@ -212,6 +212,10 @@ contract BabelVault is IBabelVault, BabelOwnable, SystemStart {
         success = true;
     }
 
+    function isReceiverActive(uint256 id) external view returns(bool isActive) {
+        isActive = idToReceiver[id].isActive;
+    }
+
     /**
         @notice Set the `emissionSchedule` contract
         @dev Callable only by the owner (the DAO admin voter, to change the emission schedule).

--- a/contracts/dependencies/BabelBase.sol
+++ b/contracts/dependencies/BabelBase.sol
@@ -40,6 +40,7 @@ contract BabelBase is IBabelBase {
     }
 
     function _requireUserAcceptsFee(uint256 _fee, uint256 _amount, uint256 _maxFeePercentage) internal pure {
+        require(_amount > 0, "Amount must be greater than zero");
         uint256 feePercentage = (_fee * BIMA_DECIMAL_PRECISION) / _amount;
         require(feePercentage <= _maxFeePercentage, "Fee exceeded provided maximum");
     }

--- a/contracts/interfaces/IBorrowerOperations.sol
+++ b/contracts/interfaces/IBorrowerOperations.sol
@@ -26,6 +26,7 @@ interface IBorrowerOperations is IBabelOwnable, IBabelBase, IDelegatedOps {
     event TroveCreated(address indexed _borrower, uint256 arrayIndex);
     event TroveManagerRemoved(ITroveManager);
     event TroveUpdated(address indexed _borrower, uint256 _debt, uint256 _coll, uint256 stake, BorrowerOperation operation);
+    event SetMinDetDebt(uint256 newMinNetDebt);
 
     function addColl(
         ITroveManager troveManager,

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -85,6 +85,8 @@ interface IBabelVault is IBabelOwnable, ISystemStart {
 
     function idToReceiver(uint256) external view returns (address account, bool isActive, uint16 updatedWeek);
 
+    function isReceiverActive(uint256 id) external view returns(bool isActive);
+
     function lockWeeks() external view returns (uint64);
 
     function locker() external view returns (ITokenLocker);

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -97,9 +97,8 @@ contract TestSetup is Test {
     BoostCalculator  internal boostCalc;
 
     // constants
-    uint64 constant internal MAX_PCT = 10000; // 100%
     uint256 internal constant INIT_GAS_COMPENSATION = 200e18;
-    uint256 internal constant INIT_MIN_NET_DEBT = 1800e18;
+    uint256 internal constant INIT_MIN_NET_DEBT = 1000e18;
     uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1e18;
     address internal constant ZERO_ADDRESS = address(0);
 
@@ -320,6 +319,11 @@ contract TestSetup is Test {
     }
 
     // common helper functions used in tests
+    function _sendStakedBtc(address user, uint256 amount) internal {
+        vm.prank(users.owner);
+        stakedBTC.transfer(user, amount);
+    }
+
     function _vaultSetDefaultInitialParameters() internal {
         uint128[] memory _fixedInitialAmounts;
         IBabelVault.InitialAllowance[] memory initialAllowances;

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -97,6 +97,14 @@ contract TestSetup is Test {
     BoostCalculator  internal boostCalc;
 
     // constants
+    uint256 internal constant INIT_MCR = 2e18; // 200%
+    uint256 internal constant INIT_MAX_DEBT = 1_000_000e18; // 1M USD
+    uint256 internal constant INIT_REDEMPTION_FEE_FLOOR = 5e15;
+    uint256 internal constant INIT_MAX_REDEMPTION_FEE = 1e18;
+    uint256 internal constant INIT_BORROWING_FEE_FLOOR = 0;
+    uint256 internal constant INIT_MAX_BORROWING_FEE = 0;
+    uint256 internal constant INIT_INTEREST_RATE_BPS = 0;
+
     uint256 internal constant INIT_GAS_COMPENSATION = 200e18;
     uint256 internal constant INIT_MIN_NET_DEBT = 1000e18;
     uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1e18;
@@ -265,13 +273,13 @@ contract TestSetup is Test {
         // to add StakedBTC as valid collateral in the protocol
         IFactory.DeploymentParams memory params = IFactory.DeploymentParams({
             minuteDecayFactor : 999037758833783000,
-            redemptionFeeFloor: 5e15,
-            maxRedemptionFee: 1e18,
-            borrowingFeeFloor: 0,
-            maxBorrowingFee: 0,
-            interestRateInBps: 0,
-            maxDebt: 1_000_000e18, // 1M USD
-            MCR: 2e18 // 200%
+            redemptionFeeFloor: INIT_REDEMPTION_FEE_FLOOR,
+            maxRedemptionFee: INIT_MAX_REDEMPTION_FEE,
+            borrowingFeeFloor: INIT_BORROWING_FEE_FLOOR,
+            maxBorrowingFee: INIT_MAX_BORROWING_FEE,
+            interestRateInBps: INIT_INTEREST_RATE_BPS,
+            maxDebt: INIT_MAX_DEBT,
+            MCR: INIT_MCR
         });
 
         factory.deployNewInstance(address(stakedBTC), 

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -117,6 +117,8 @@ contract TestSetup is Test {
     uint256 internal constant INIT_BAB_TKN_TOTAL_SUPPLY = type(uint32).max*INIT_LOCK_TO_TOKEN_RATIO;
     uint64 internal constant INIT_VLT_LOCK_WEEKS = 2;
 
+    uint256 internal constant MIN_BTC_PRICE_8DEC = 10_000  * 10 ** 8;
+    uint256 internal constant MAX_BTC_PRICE_8DEC = 500_000 * 10 ** 8;
 
     function setUp() public virtual {
         // prevent Foundry from setting block.timestamp = 1 which can cause
@@ -330,6 +332,10 @@ contract TestSetup is Test {
     function _sendStakedBtc(address user, uint256 amount) internal {
         vm.prank(users.owner);
         stakedBTC.transfer(user, amount);
+    }
+
+    function _getScaledOraclePrice() internal view returns(uint256 scaledPrice) {
+        scaledPrice = uint256(mockOracle.answer()) * 10 ** 10;
     }
 
     function _vaultSetDefaultInitialParameters() internal {

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -105,7 +105,7 @@ contract TestSetup is Test {
     uint256 internal constant INIT_MAX_BORROWING_FEE = 0;
     uint256 internal constant INIT_INTEREST_RATE_BPS = 0;
 
-    uint256 internal constant INIT_GAS_COMPENSATION = 200e18;
+    uint256 internal constant INIT_GAS_COMPENSATION = 1e18;
     uint256 internal constant INIT_MIN_NET_DEBT = 1000e18;
     uint256 internal constant INIT_LOCK_TO_TOKEN_RATIO = 1e18;
     address internal constant ZERO_ADDRESS = address(0);

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup, IBorrowerOperations} from "../TestSetup.sol";
+
+import {BabelMath} from "../../../contracts/dependencies/BabelMath.sol";
+import {ITroveManager, IERC20} from "../../../contracts/interfaces/ITroveManager.sol";
+
+contract BorrowerOperationsTest is TestSetup {
+
+    ITroveManager stakedBTCTroveMgr;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // verify factory has deployed 1 TroveManager which has
+        // StakedBTC as its collateral token
+        assertEq(factory.troveManagerCount(), 1);
+        stakedBTCTroveMgr = ITroveManager(factory.troveManagers(0));
+        assertEq(address(stakedBTCTroveMgr.collateralToken()), address(stakedBTC));
+
+        // verify StakedBTCTroveMgr has been registered with BorrowerOperations
+        assertEq(borrowerOps.getTroveManagersCount(), 1);
+
+        (IERC20 collateralToken, uint16 index) = borrowerOps.troveManagersData(stakedBTCTroveMgr);
+        assertEq(address(collateralToken), address(stakedBTC));
+        assertEq(index, 0);
+    }
+
+    function test_openTrove_failInvalidTroveManager() external {
+        vm.expectRevert("Collateral not enabled");
+        vm.prank(users.user1);
+        borrowerOps.openTrove(troveMgr, users.user1, 1e18, 1e18, 0, address(0), address(0));
+    }
+
+    function test_openTrove_fuzz(uint256 collateralAmount) external {
+        // bound fuzz inputs
+        collateralAmount = bound(collateralAmount, 4e16, 1_000_000e18);
+
+        // get max debt possible
+        uint256 debtAmount = BabelMath._min(INIT_MAX_DEBT - INIT_GAS_COMPENSATION,
+                                            collateralAmount * 26566);
+
+        _sendStakedBtc(users.user1, collateralAmount);
+
+        vm.prank(users.user1);
+        stakedBTC.approve(address(borrowerOps), collateralAmount);
+
+        vm.prank(users.user1);
+        borrowerOps.openTrove(stakedBTCTroveMgr,
+                              users.user1,
+                              0, // maxFeePercentage
+                              collateralAmount,
+                              debtAmount,
+                              address(0), address(0)); // hints
+
+        // verify borrower received debt tokens
+        assertEq(debtToken.balanceOf(users.user1), debtAmount);
+
+        // verify gas pool received gas compensation tokens
+        assertEq(debtToken.balanceOf(users.gasPool), INIT_GAS_COMPENSATION);
+
+        // verify TroveManager received collateral tokens
+        assertEq(stakedBTC.balanceOf(address(stakedBTCTroveMgr)), collateralAmount);
+
+        // verify system balances
+        IBorrowerOperations.SystemBalances memory balances = borrowerOps.fetchBalances();
+        assertEq(balances.collaterals.length, 1);
+        assertEq(balances.collaterals.length, balances.debts.length);
+        assertEq(balances.collaterals.length, balances.prices.length);
+
+        assertEq(balances.collaterals[0], collateralAmount);
+        assertEq(balances.debts[0], debtAmount + INIT_GAS_COMPENSATION);
+        assertEq(balances.prices[0], uint256(mockOracle.answer() * 10 ** 10));
+    }
+
+    function test_openTrove_custom() external {
+        // depositing 2 BTC collateral (price = $60,000 in MockOracle)
+        uint256 collateralAmount = 2e18;
+
+        // get max debt possible
+        uint256 debtAmount = 53_133e18;
+
+        _sendStakedBtc(users.user1, collateralAmount);
+
+        vm.prank(users.user1);
+        stakedBTC.approve(address(borrowerOps), collateralAmount);
+
+        vm.prank(users.user1);
+        borrowerOps.openTrove(stakedBTCTroveMgr,
+                              users.user1,
+                              0, // maxFeePercentage
+                              collateralAmount,
+                              debtAmount,
+                              address(0), address(0)); // hints
+
+        // verify borrower received debt tokens
+        assertEq(debtToken.balanceOf(users.user1), debtAmount);
+
+        // verify gas pool received gas compensation tokens
+        assertEq(debtToken.balanceOf(users.gasPool), INIT_GAS_COMPENSATION);
+
+        // verify TroveManager received collateral tokens
+        assertEq(stakedBTC.balanceOf(address(stakedBTCTroveMgr)), collateralAmount);
+
+        // verify system balances
+        IBorrowerOperations.SystemBalances memory balances = borrowerOps.fetchBalances();
+        assertEq(balances.collaterals.length, 1);
+        assertEq(balances.collaterals.length, balances.debts.length);
+        assertEq(balances.collaterals.length, balances.prices.length);
+
+        assertEq(balances.collaterals[0], collateralAmount);
+        assertEq(balances.debts[0], debtAmount + INIT_GAS_COMPENSATION);
+        assertEq(balances.prices[0], uint256(mockOracle.answer() * 10 ** 10));
+    }
+
+
+
+
+}

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -10,6 +10,8 @@ import {ITroveManager, IERC20} from "../../../contracts/interfaces/ITroveManager
 contract BorrowerOperationsTest is TestSetup {
 
     ITroveManager stakedBTCTroveMgr;
+    uint256 internal minCollateral;
+    uint256 internal maxCollateral;
 
     function setUp() public virtual override {
         super.setUp();
@@ -26,6 +28,9 @@ contract BorrowerOperationsTest is TestSetup {
         (IERC20 collateralToken, uint16 index) = borrowerOps.troveManagersData(stakedBTCTroveMgr);
         assertEq(address(collateralToken), address(stakedBTC));
         assertEq(index, 0);
+
+        minCollateral = 3e17;
+        maxCollateral = 1_000_000e18;
     }
 
     function test_openTrove_failInvalidTroveManager() external {
@@ -34,9 +39,44 @@ contract BorrowerOperationsTest is TestSetup {
         borrowerOps.openTrove(troveMgr, users.user1, 1e18, 1e18, 0, address(0), address(0));
     }
 
-    function test_openTrove(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) external {
+    // helper function to open a trove
+    function _openTrove(address user, uint256 collateralAmount, uint256 debtAmount) internal {
+        _sendStakedBtc(user, collateralAmount);
+
+        vm.prank(user);
+        stakedBTC.approve(address(borrowerOps), collateralAmount);
+
+        vm.prank(user);
+        borrowerOps.openTrove(stakedBTCTroveMgr,
+                              user,
+                              0, // maxFeePercentage
+                              collateralAmount,
+                              debtAmount,
+                              address(0), address(0)); // hints
+
+        // verify borrower received debt tokens
+        assertEq(debtToken.balanceOf(user), debtAmount);
+
+        // verify gas pool received gas compensation tokens
+        assertEq(debtToken.balanceOf(users.gasPool), INIT_GAS_COMPENSATION);
+
+        // verify TroveManager received collateral tokens
+        assertEq(stakedBTC.balanceOf(address(stakedBTCTroveMgr)), collateralAmount);
+
+        // verify system balances
+        IBorrowerOperations.SystemBalances memory balances = borrowerOps.fetchBalances();
+        assertEq(balances.collaterals.length, 1);
+        assertEq(balances.collaterals.length, balances.debts.length);
+        assertEq(balances.collaterals.length, balances.prices.length);
+
+        assertEq(balances.collaterals[0], collateralAmount);
+        assertEq(balances.debts[0], debtAmount + INIT_GAS_COMPENSATION);
+        assertEq(balances.prices[0], _getScaledOraclePrice());
+    }
+
+    function test_openTrove(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) public {
         // bound fuzz inputs
-        collateralAmount = bound(collateralAmount, 3e17, 1_000_000e18);
+        collateralAmount = bound(collateralAmount, minCollateral, maxCollateral);
         btcPrice = bound(btcPrice, MIN_BTC_PRICE_8DEC, MAX_BTC_PRICE_8DEC);
 
         // set new btc price with mock oracle
@@ -57,78 +97,123 @@ contract BorrowerOperationsTest is TestSetup {
         // get random debt between min and max possible for random collateral amount
         debtAmount = bound(debtAmount, INIT_MIN_NET_DEBT, debtAmountMax);                                
 
-        _sendStakedBtc(users.user1, collateralAmount);
-
-        vm.prank(users.user1);
-        stakedBTC.approve(address(borrowerOps), collateralAmount);
-
-        vm.prank(users.user1);
-        borrowerOps.openTrove(stakedBTCTroveMgr,
-                              users.user1,
-                              0, // maxFeePercentage
-                              collateralAmount,
-                              debtAmount,
-                              address(0), address(0)); // hints
-
-        // verify borrower received debt tokens
-        assertEq(debtToken.balanceOf(users.user1), debtAmount);
-
-        // verify gas pool received gas compensation tokens
-        assertEq(debtToken.balanceOf(users.gasPool), INIT_GAS_COMPENSATION);
-
-        // verify TroveManager received collateral tokens
-        assertEq(stakedBTC.balanceOf(address(stakedBTCTroveMgr)), collateralAmount);
-
-        // verify system balances
-        IBorrowerOperations.SystemBalances memory balances = borrowerOps.fetchBalances();
-        assertEq(balances.collaterals.length, 1);
-        assertEq(balances.collaterals.length, balances.debts.length);
-        assertEq(balances.collaterals.length, balances.prices.length);
-
-        assertEq(balances.collaterals[0], collateralAmount);
-        assertEq(balances.debts[0], debtAmount + INIT_GAS_COMPENSATION);
-        assertEq(balances.prices[0], _getScaledOraclePrice());
+        _openTrove(users.user1, collateralAmount, debtAmount);
     }
 
     function test_openTrove_custom() external {
         // depositing 2 BTC collateral (price = $60,000 in MockOracle)
+        // use this test to experiment with different hard-coded values
         uint256 collateralAmount = 2e18;
 
         uint256 debtAmountMax
             = (collateralAmount * _getScaledOraclePrice() / borrowerOps.CCR())
               - INIT_GAS_COMPENSATION;
 
-        _sendStakedBtc(users.user1, collateralAmount);
+        _openTrove(users.user1, collateralAmount, debtAmountMax);
+    }
 
+    function test_addColl(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) public
+        returns (uint256 addedCollateral) {
+        // first limit the max collateral to ensure enough tokens remain
+        maxCollateral /= 2;
+
+        // bound fuzz inputs
+        addedCollateral = bound(collateralAmount, 1, maxCollateral);
+
+        // then open a new trove
+        test_openTrove(collateralAmount, debtAmount, btcPrice);
+
+        // give user extra staked btc collateral
+        _sendStakedBtc(users.user1, addedCollateral);
+
+        // save pre state
+        uint256 userDebtTokenBalPre = debtToken.balanceOf(users.user1);
+        uint256 gasPoolDebtTokenBalPre = debtToken.balanceOf(users.gasPool);
+        uint256 troveMgrSBTCBalPre = stakedBTC.balanceOf(address(stakedBTCTroveMgr));
+
+        IBorrowerOperations.SystemBalances memory sysBalancesPre = borrowerOps.fetchBalances();
+        assertEq(sysBalancesPre.collaterals.length, 1);
+        assertEq(sysBalancesPre.collaterals.length, sysBalancesPre.debts.length);
+        assertEq(sysBalancesPre.collaterals.length, sysBalancesPre.prices.length);
+
+        // transfer approval
         vm.prank(users.user1);
-        stakedBTC.approve(address(borrowerOps), collateralAmount);
+        stakedBTC.approve(address(borrowerOps), addedCollateral);
 
+        // add the new collateral to the existing trove
         vm.prank(users.user1);
-        borrowerOps.openTrove(stakedBTCTroveMgr,
-                              users.user1,
-                              0, // maxFeePercentage
-                              collateralAmount,
-                              debtAmountMax,
-                              address(0), address(0)); // hints
+        borrowerOps.addColl(stakedBTCTroveMgr,
+                            users.user1,
+                            addedCollateral,
+                            address(0), address(0)); // hints
 
-        // verify borrower received debt tokens
-        assertEq(debtToken.balanceOf(users.user1), debtAmountMax);
+        // verify borrower received no new debt tokens
+        assertEq(debtToken.balanceOf(users.user1), userDebtTokenBalPre);
 
-        // verify gas pool received gas compensation tokens
-        assertEq(debtToken.balanceOf(users.gasPool), INIT_GAS_COMPENSATION);
+        // verify gas pool received no new gas compensation tokens
+        assertEq(debtToken.balanceOf(users.gasPool), gasPoolDebtTokenBalPre);
 
-        // verify TroveManager received collateral tokens
-        assertEq(stakedBTC.balanceOf(address(stakedBTCTroveMgr)), collateralAmount);
+        // verify TroveManager received additional collateral tokens
+        assertEq(stakedBTC.balanceOf(address(stakedBTCTroveMgr)), troveMgrSBTCBalPre + addedCollateral);
 
         // verify system balances
-        IBorrowerOperations.SystemBalances memory balances = borrowerOps.fetchBalances();
-        assertEq(balances.collaterals.length, 1);
-        assertEq(balances.collaterals.length, balances.debts.length);
-        assertEq(balances.collaterals.length, balances.prices.length);
+        IBorrowerOperations.SystemBalances memory sysBalancesPost = borrowerOps.fetchBalances();
+        assertEq(sysBalancesPost.collaterals.length, 1);
+        assertEq(sysBalancesPost.collaterals.length, sysBalancesPost.debts.length);
+        assertEq(sysBalancesPost.collaterals.length, sysBalancesPost.prices.length);
 
-        assertEq(balances.collaterals[0], collateralAmount);
-        assertEq(balances.debts[0], debtAmountMax + INIT_GAS_COMPENSATION);
-        assertEq(balances.prices[0], _getScaledOraclePrice());
+        assertEq(sysBalancesPost.collaterals[0], sysBalancesPre.collaterals[0] + addedCollateral);
+        assertEq(sysBalancesPost.debts[0], sysBalancesPre.debts[0]);
+        assertEq(sysBalancesPost.prices[0], sysBalancesPre.prices[0]);
+    }
+
+    function test_withdrawColl(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) external
+        returns(uint256 withdrawnCollateral) {
+        // first open a trove and add some extra collateral
+        uint256 addedCollateral = test_addColl(collateralAmount, debtAmount, btcPrice);
+
+        // bound fuzz inputs
+        withdrawnCollateral = bound(addedCollateral, 1, addedCollateral);
+
+        // save pre state
+        uint256 userSBTCBalPre = stakedBTC.balanceOf(users.user1);
+        uint256 userDebtTokenBalPre = debtToken.balanceOf(users.user1);
+        uint256 gasPoolDebtTokenBalPre = debtToken.balanceOf(users.gasPool);
+        uint256 troveMgrSBTCBalPre = stakedBTC.balanceOf(address(stakedBTCTroveMgr));
+        
+        IBorrowerOperations.SystemBalances memory sysBalancesPre = borrowerOps.fetchBalances();
+        assertEq(sysBalancesPre.collaterals.length, 1);
+        assertEq(sysBalancesPre.collaterals.length, sysBalancesPre.debts.length);
+        assertEq(sysBalancesPre.collaterals.length, sysBalancesPre.prices.length);
+
+        // withdraw the extra collateral
+        vm.prank(users.user1);
+        borrowerOps.withdrawColl(stakedBTCTroveMgr,
+                                 users.user1,
+                                 withdrawnCollateral,
+                                 address(0), address(0)); // hints
+
+        // verify borrower received no new debt tokens
+        assertEq(debtToken.balanceOf(users.user1), userDebtTokenBalPre);
+
+        // verify gas pool received no new gas compensation tokens
+        assertEq(debtToken.balanceOf(users.gasPool), gasPoolDebtTokenBalPre);
+
+        // verify TroveManager sent withdrawn collateral tokens
+        assertEq(stakedBTC.balanceOf(address(stakedBTCTroveMgr)), troveMgrSBTCBalPre - withdrawnCollateral);
+
+        // verify user received withdrawn collateral tokens
+        assertEq(stakedBTC.balanceOf(users.user1), userSBTCBalPre + withdrawnCollateral);
+
+        // verify system balances
+        IBorrowerOperations.SystemBalances memory sysBalancesPost = borrowerOps.fetchBalances();
+        assertEq(sysBalancesPost.collaterals.length, 1);
+        assertEq(sysBalancesPost.collaterals.length, sysBalancesPost.debts.length);
+        assertEq(sysBalancesPost.collaterals.length, sysBalancesPost.prices.length);
+
+        assertEq(sysBalancesPost.collaterals[0], sysBalancesPre.collaterals[0] - withdrawnCollateral);
+        assertEq(sysBalancesPost.debts[0], sysBalancesPre.debts[0]);
+        assertEq(sysBalancesPost.prices[0], sysBalancesPre.prices[0]);
     }
 
 

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -9,7 +9,7 @@ import {ITroveManager, IERC20} from "../../../contracts/interfaces/ITroveManager
 
 contract BorrowerOperationsTest is TestSetup {
 
-    ITroveManager stakedBTCTroveMgr;
+    ITroveManager internal stakedBTCTroveMgr;
     uint256 internal minCollateral;
     uint256 internal maxCollateral;
 
@@ -95,7 +95,7 @@ contract BorrowerOperationsTest is TestSetup {
     }
 
     function test_openTrove(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) public
-        returns(uint256 actualCollateralAmount) {
+        returns(uint256 actualCollateralAmount, uint256 actualDebtAmount) {
         // bound fuzz inputs
         actualCollateralAmount = bound(collateralAmount, minCollateral, maxCollateral);
         btcPrice = bound(btcPrice, MIN_BTC_PRICE_8DEC, MAX_BTC_PRICE_8DEC);
@@ -116,9 +116,9 @@ contract BorrowerOperationsTest is TestSetup {
                               - INIT_GAS_COMPENSATION);
 
         // get random debt between min and max possible for random collateral amount
-        debtAmount = bound(debtAmount, INIT_MIN_NET_DEBT, debtAmountMax);                                
+        actualDebtAmount = bound(debtAmount, INIT_MIN_NET_DEBT, debtAmountMax);                                
 
-        _openTrove(users.user1, actualCollateralAmount, debtAmount);
+        _openTrove(users.user1, actualCollateralAmount, actualDebtAmount);
     }
 
     function test_openTrove_custom() external {
@@ -273,7 +273,7 @@ contract BorrowerOperationsTest is TestSetup {
 
     function test_closeTrove(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) external {
         // first open a new trove
-        uint256 actualCollateralAmount = test_openTrove(collateralAmount, debtAmount, btcPrice);
+        (uint256 actualCollateralAmount, ) = test_openTrove(collateralAmount, debtAmount, btcPrice);
 
         // save pre state
         BorrowerOpsState memory statePre = _getBorrowerOpsState();

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -34,13 +34,16 @@ contract BorrowerOperationsTest is TestSetup {
         borrowerOps.openTrove(troveMgr, users.user1, 1e18, 1e18, 0, address(0), address(0));
     }
 
-    function test_openTrove_fuzz(uint256 collateralAmount) external {
+    function test_openTrove_fuzz(uint256 collateralAmount, uint256 debtAmount) external {
         // bound fuzz inputs
         collateralAmount = bound(collateralAmount, 4e16, 1_000_000e18);
 
-        // get max debt possible
-        uint256 debtAmount = BabelMath._min(INIT_MAX_DEBT - INIT_GAS_COMPENSATION,
-                                            collateralAmount * 26566);
+        // get max debt possible for random collateral amount
+        uint256 debtAmountMax = BabelMath._min(INIT_MAX_DEBT - INIT_GAS_COMPENSATION,
+                                               collateralAmount * 26566);
+
+        // get random debt between min and max possible for random collateral amount
+        debtAmount = bound(debtAmount, INIT_MIN_NET_DEBT, debtAmountMax);                                
 
         _sendStakedBtc(users.user1, collateralAmount);
 

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -2,12 +2,14 @@
 pragma solidity 0.8.19;
 
 // test setup
-import {TestSetup, IBorrowerOperations} from "../TestSetup.sol";
+import {IBorrowerOperations} from "../TestSetup.sol";
+
+import {StabilityPoolTest} from "./StabilityPoolTest.t.sol";
 
 import {BabelMath} from "../../../contracts/dependencies/BabelMath.sol";
 import {ITroveManager, IERC20} from "../../../contracts/interfaces/ITroveManager.sol";
 
-contract BorrowerOperationsTest is TestSetup {
+contract BorrowerOperationsTest is StabilityPoolTest {
 
     ITroveManager internal stakedBTCTroveMgr;
     uint256 internal minCollateral;

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -34,13 +34,25 @@ contract BorrowerOperationsTest is TestSetup {
         borrowerOps.openTrove(troveMgr, users.user1, 1e18, 1e18, 0, address(0), address(0));
     }
 
-    function test_openTrove_fuzz(uint256 collateralAmount, uint256 debtAmount) external {
+    function test_openTrove(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) external {
         // bound fuzz inputs
-        collateralAmount = bound(collateralAmount, 4e16, 1_000_000e18);
+        collateralAmount = bound(collateralAmount, 3e17, 1_000_000e18);
+        btcPrice = bound(btcPrice, MIN_BTC_PRICE_8DEC, MAX_BTC_PRICE_8DEC);
 
-        // get max debt possible for random collateral amount
-        uint256 debtAmountMax = BabelMath._min(INIT_MAX_DEBT - INIT_GAS_COMPENSATION,
-                                               collateralAmount * 26566);
+        // set new btc price with mock oracle
+        mockOracle.setResponse(mockOracle.roundId() + 1,
+                               int256(btcPrice),
+                               block.timestamp + 1,
+                               block.timestamp + 1,
+                               mockOracle.answeredInRound() + 1);
+        // warp time to prevent cached price being used
+        vm.warp(block.timestamp + 1);
+
+        // get max debt possible for random collateral amount and random btc price
+        uint256 debtAmountMax
+            = BabelMath._min(INIT_MAX_DEBT - INIT_GAS_COMPENSATION,
+                             (collateralAmount * _getScaledOraclePrice() / borrowerOps.CCR())
+                              - INIT_GAS_COMPENSATION);
 
         // get random debt between min and max possible for random collateral amount
         debtAmount = bound(debtAmount, INIT_MIN_NET_DEBT, debtAmountMax);                                
@@ -75,15 +87,16 @@ contract BorrowerOperationsTest is TestSetup {
 
         assertEq(balances.collaterals[0], collateralAmount);
         assertEq(balances.debts[0], debtAmount + INIT_GAS_COMPENSATION);
-        assertEq(balances.prices[0], uint256(mockOracle.answer() * 10 ** 10));
+        assertEq(balances.prices[0], _getScaledOraclePrice());
     }
 
     function test_openTrove_custom() external {
         // depositing 2 BTC collateral (price = $60,000 in MockOracle)
         uint256 collateralAmount = 2e18;
 
-        // get max debt possible
-        uint256 debtAmount = 53_133e18;
+        uint256 debtAmountMax
+            = (collateralAmount * _getScaledOraclePrice() / borrowerOps.CCR())
+              - INIT_GAS_COMPENSATION;
 
         _sendStakedBtc(users.user1, collateralAmount);
 
@@ -95,11 +108,11 @@ contract BorrowerOperationsTest is TestSetup {
                               users.user1,
                               0, // maxFeePercentage
                               collateralAmount,
-                              debtAmount,
+                              debtAmountMax,
                               address(0), address(0)); // hints
 
         // verify borrower received debt tokens
-        assertEq(debtToken.balanceOf(users.user1), debtAmount);
+        assertEq(debtToken.balanceOf(users.user1), debtAmountMax);
 
         // verify gas pool received gas compensation tokens
         assertEq(debtToken.balanceOf(users.gasPool), INIT_GAS_COMPENSATION);
@@ -114,8 +127,8 @@ contract BorrowerOperationsTest is TestSetup {
         assertEq(balances.collaterals.length, balances.prices.length);
 
         assertEq(balances.collaterals[0], collateralAmount);
-        assertEq(balances.debts[0], debtAmount + INIT_GAS_COMPENSATION);
-        assertEq(balances.prices[0], uint256(mockOracle.answer() * 10 ** 10));
+        assertEq(balances.debts[0], debtAmountMax + INIT_GAS_COMPENSATION);
+        assertEq(balances.prices[0], _getScaledOraclePrice());
     }
 
 

--- a/test/foundry/core/LiquidationManagerTest.t.sol
+++ b/test/foundry/core/LiquidationManagerTest.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.19;
 
 // test setup
 import {BorrowerOperationsTest} from "./BorrowerOperationsTest.t.sol";
+import {BIMA_DECIMAL_PRECISION} from "../../../contracts/dependencies/Constants.sol";
 
 contract LiquidationManagerTest is BorrowerOperationsTest {
 
@@ -13,31 +14,20 @@ contract LiquidationManagerTest is BorrowerOperationsTest {
         assertTrue(liquidationMgr.isTroveManagerEnabled(stakedBTCTroveMgr));
     }
 
-    /* fuzz version - not working yet, get hard-coded version working first
-    function test_liquidate(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) external {
-        // first open a new trove
-        (uint256 actualCollateralAmount, uint256 actualDebtAmount)
-            = test_openTrove(collateralAmount, debtAmount, btcPrice);
+    // helper functions
+    function _getCollGasCompensation(uint256 coll) internal view returns (uint256 result) {
+        result = coll / liquidationMgr.PERCENT_DIVISOR();
+    }
 
-        // new trove should never be immediately subject to liquidation
-        vm.expectRevert("LiquidationManager: nothing to liquidate");
-        liquidationMgr.liquidate(stakedBTCTroveMgr, users.user1);
+    // used to save important state for verification
+    struct StateData {
+        uint256 userDebt;
+        uint256 userColl;
+        uint256 userPendingDebtReward;
+        uint256 userPendingCollateralReward;
+    }
 
-        // set new btc price / 2 with mock oracle
-        mockOracle.setResponse(mockOracle.roundId() + 1,
-                               int256(0),
-                               block.timestamp + 1,
-                               block.timestamp + 1,
-                               mockOracle.answeredInRound() + 1);
-        // warp time to prevent cached price being used
-        vm.warp(block.timestamp + 1);
-
-        // then liquidate the user
-        liquidationMgr.liquidate(stakedBTCTroveMgr, users.user1);
-    }*/
-
-
-    function test_impossibleToLiquidateSingleBorrower() external {
+    function test_liquidateTroves_onlyOneTrove() external {
         // depositing 2 BTC collateral (price = $60,000 in MockOracle)
         // use this test to experiment with different hard-coded values
         uint256 collateralAmount = 2e18;
@@ -48,25 +38,112 @@ contract LiquidationManagerTest is BorrowerOperationsTest {
 
         _openTrove(users.user1, collateralAmount, debtAmountMax);
 
-        // set new value of btc to $1 which should ensure liquidation
+        // set new value of btc to $50,000 to make trove liquidatable
         mockOracle.setResponse(mockOracle.roundId() + 1,
-                               int256(1 * 10 ** 8),
+                               int256(50000 * 10 ** 8),
                                block.timestamp + 1,
                                block.timestamp + 1,
                                mockOracle.answeredInRound() + 1);
         // warp time to prevent cached price being used
         vm.warp(block.timestamp + 1);
 
-        // then liquidate the user - but it fails since the
-        // `while` and `for` loops get bypassed when there is
-        // only 1 active borrower!
-        vm.expectRevert("LiquidationManager: nothing to liquidate");
+        // save previous state
+        StateData memory statePre;
+        (statePre.userDebt, statePre.userColl, statePre.userPendingDebtReward, statePre.userPendingCollateralReward)
+            = stakedBTCTroveMgr.getEntireDebtAndColl(users.user1);
+
+        // liquidate via `liquidateTroves`
+        liquidationMgr.liquidateTroves(stakedBTCTroveMgr, 1, stakedBTCTroveMgr.MCR());
+
+        // user after state all zeros
+        StateData memory statePost;
+        (statePost.userDebt, statePost.userColl, statePost.userPendingDebtReward, statePost.userPendingCollateralReward)
+            = stakedBTCTroveMgr.getEntireDebtAndColl(users.user1);
+        assertEq(statePost.userDebt, 0);
+        assertEq(statePost.userColl, 0);
+        assertEq(statePost.userPendingDebtReward, 0);
+        assertEq(statePost.userPendingCollateralReward, 0);
+
+        // since there was only 1 trove, these should also be zero
+        assertEq(stakedBTCTroveMgr.getTotalActiveDebt(), 0);
+        assertEq(stakedBTCTroveMgr.getTotalActiveCollateral(), 0);
+
+        // verify default debt & collateral calculated correctly
+        assertEq(stakedBTCTroveMgr.defaultedDebt(),
+                 statePre.userDebt + statePre.userPendingDebtReward);
+        assertEq(stakedBTCTroveMgr.defaultedCollateral(),
+                 statePre.userColl - _getCollGasCompensation(statePre.userColl));
+
+        // just default values * BIMA_DECIMAL_PRECISION as no previous errors
+        // and only 1 trove total (the one being liquidated)
+        assertEq(stakedBTCTroveMgr.L_collateral(),
+                 stakedBTCTroveMgr.defaultedCollateral() * BIMA_DECIMAL_PRECISION);
+        assertEq(stakedBTCTroveMgr.L_debt(),
+                 stakedBTCTroveMgr.defaultedDebt() * BIMA_DECIMAL_PRECISION);
+
+        // no errors
+        assertEq(stakedBTCTroveMgr.lastCollateralError_Redistribution(), 0);
+        assertEq(stakedBTCTroveMgr.lastDebtError_Redistribution(), 0);
+    }
+
+    function test_liquidate_onlyOneTrove() external {
+        // depositing 2 BTC collateral (price = $60,000 in MockOracle)
+        // use this test to experiment with different hard-coded values
+        uint256 collateralAmount = 2e18;
+
+        uint256 debtAmountMax
+            = (collateralAmount * _getScaledOraclePrice() / borrowerOps.CCR())
+              - INIT_GAS_COMPENSATION;
+
+        _openTrove(users.user1, collateralAmount, debtAmountMax);
+
+        // set new value of btc to $50,000 to make trove liquidatable
+        mockOracle.setResponse(mockOracle.roundId() + 1,
+                               int256(50000 * 10 ** 8),
+                               block.timestamp + 1,
+                               block.timestamp + 1,
+                               mockOracle.answeredInRound() + 1);
+        // warp time to prevent cached price being used
+        vm.warp(block.timestamp + 1);
+
+        // save previous state
+        StateData memory statePre;
+        (statePre.userDebt, statePre.userColl, statePre.userPendingDebtReward, statePre.userPendingCollateralReward)
+            = stakedBTCTroveMgr.getEntireDebtAndColl(users.user1);
+
+        // liquidate via `liquidate`
         liquidationMgr.liquidate(stakedBTCTroveMgr, users.user1);
 
-        // attempting to use the other liquidation function has same problem
-        uint256 mcr = stakedBTCTroveMgr.MCR();
-        vm.expectRevert("LiquidationManager: nothing to liquidate");
-        liquidationMgr.liquidateTroves(stakedBTCTroveMgr, 1, mcr);
-        // the borrower is impossible to liquidate
+        // user after state all zeros
+        StateData memory statePost;
+        (statePost.userDebt, statePost.userColl, statePost.userPendingDebtReward, statePost.userPendingCollateralReward)
+            = stakedBTCTroveMgr.getEntireDebtAndColl(users.user1);
+        assertEq(statePost.userDebt, 0);
+        assertEq(statePost.userColl, 0);
+        assertEq(statePost.userPendingDebtReward, 0);
+        assertEq(statePost.userPendingCollateralReward, 0);
+
+        // since there was only 1 trove, these should also be zero
+        assertEq(stakedBTCTroveMgr.getTotalActiveDebt(), 0);
+        assertEq(stakedBTCTroveMgr.getTotalActiveCollateral(), 0);
+
+        // verify default debt & collateral calculated correctly
+        assertEq(stakedBTCTroveMgr.defaultedDebt(),
+                 statePre.userDebt + statePre.userPendingDebtReward);
+        assertEq(stakedBTCTroveMgr.defaultedCollateral(),
+                 statePre.userColl - _getCollGasCompensation(statePre.userColl));
+
+        // just default values * BIMA_DECIMAL_PRECISION as no previous errors
+        // and only 1 trove total (the one being liquidated)
+        assertEq(stakedBTCTroveMgr.L_collateral(),
+                 stakedBTCTroveMgr.defaultedCollateral() * BIMA_DECIMAL_PRECISION);
+        assertEq(stakedBTCTroveMgr.L_debt(),
+                 stakedBTCTroveMgr.defaultedDebt() * BIMA_DECIMAL_PRECISION);
+
+        // no errors
+        assertEq(stakedBTCTroveMgr.lastCollateralError_Redistribution(), 0);
+        assertEq(stakedBTCTroveMgr.lastDebtError_Redistribution(), 0);
     }
+
+
 }

--- a/test/foundry/core/LiquidationManagerTest.t.sol
+++ b/test/foundry/core/LiquidationManagerTest.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {BorrowerOperationsTest} from "./BorrowerOperationsTest.t.sol";
+
+contract LiquidationManagerTest is BorrowerOperationsTest {
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // verify staked btc trove manager enabled for liquidation
+        assertTrue(liquidationMgr.isTroveManagerEnabled(stakedBTCTroveMgr));
+    }
+
+    /* fuzz version - not working yet, get hard-coded version working first
+    function test_liquidate(uint256 collateralAmount, uint256 debtAmount, uint256 btcPrice) external {
+        // first open a new trove
+        (uint256 actualCollateralAmount, uint256 actualDebtAmount)
+            = test_openTrove(collateralAmount, debtAmount, btcPrice);
+
+        // new trove should never be immediately subject to liquidation
+        vm.expectRevert("LiquidationManager: nothing to liquidate");
+        liquidationMgr.liquidate(stakedBTCTroveMgr, users.user1);
+
+        // set new btc price / 2 with mock oracle
+        mockOracle.setResponse(mockOracle.roundId() + 1,
+                               int256(0),
+                               block.timestamp + 1,
+                               block.timestamp + 1,
+                               mockOracle.answeredInRound() + 1);
+        // warp time to prevent cached price being used
+        vm.warp(block.timestamp + 1);
+
+        // then liquidate the user
+        liquidationMgr.liquidate(stakedBTCTroveMgr, users.user1);
+    }*/
+
+
+    function test_impossibleToLiquidateSingleBorrower() external {
+        // depositing 2 BTC collateral (price = $60,000 in MockOracle)
+        // use this test to experiment with different hard-coded values
+        uint256 collateralAmount = 2e18;
+
+        uint256 debtAmountMax
+            = (collateralAmount * _getScaledOraclePrice() / borrowerOps.CCR())
+              - INIT_GAS_COMPENSATION;
+
+        _openTrove(users.user1, collateralAmount, debtAmountMax);
+
+        // set new value of btc to $1 which should ensure liquidation
+        mockOracle.setResponse(mockOracle.roundId() + 1,
+                               int256(1 * 10 ** 8),
+                               block.timestamp + 1,
+                               block.timestamp + 1,
+                               mockOracle.answeredInRound() + 1);
+        // warp time to prevent cached price being used
+        vm.warp(block.timestamp + 1);
+
+        // then liquidate the user - but it fails since the
+        // `while` and `for` loops get bypassed when there is
+        // only 1 active borrower!
+        vm.expectRevert("LiquidationManager: nothing to liquidate");
+        liquidationMgr.liquidate(stakedBTCTroveMgr, users.user1);
+
+        // attempting to use the other liquidation function has same problem
+        uint256 mcr = stakedBTCTroveMgr.MCR();
+        vm.expectRevert("LiquidationManager: nothing to liquidate");
+        liquidationMgr.liquidateTroves(stakedBTCTroveMgr, 1, mcr);
+        // the borrower is impossible to liquidate
+    }
+}

--- a/test/foundry/core/LiquidationManagerTest.t.sol
+++ b/test/foundry/core/LiquidationManagerTest.t.sol
@@ -68,13 +68,13 @@ contract LiquidationManagerTest is BorrowerOperationsTest {
         assertEq(stakedBTCTroveMgr.getTotalActiveDebt(), 0);
         assertEq(stakedBTCTroveMgr.getTotalActiveCollateral(), 0);
 
-        // verify default debt & collateral calculated correctly
+        // verify defaulted debt & collateral calculated correctly
         assertEq(stakedBTCTroveMgr.defaultedDebt(),
                  statePre.userDebt + statePre.userPendingDebtReward);
         assertEq(stakedBTCTroveMgr.defaultedCollateral(),
                  statePre.userColl - _getCollGasCompensation(statePre.userColl));
 
-        // just default values * BIMA_DECIMAL_PRECISION as no previous errors
+        // just defaulted values * BIMA_DECIMAL_PRECISION as no previous errors
         // and only 1 trove total (the one being liquidated)
         assertEq(stakedBTCTroveMgr.L_collateral(),
                  stakedBTCTroveMgr.defaultedCollateral() * BIMA_DECIMAL_PRECISION);
@@ -127,13 +127,13 @@ contract LiquidationManagerTest is BorrowerOperationsTest {
         assertEq(stakedBTCTroveMgr.getTotalActiveDebt(), 0);
         assertEq(stakedBTCTroveMgr.getTotalActiveCollateral(), 0);
 
-        // verify default debt & collateral calculated correctly
+        // verify defaulted debt & collateral calculated correctly
         assertEq(stakedBTCTroveMgr.defaultedDebt(),
                  statePre.userDebt + statePre.userPendingDebtReward);
         assertEq(stakedBTCTroveMgr.defaultedCollateral(),
                  statePre.userColl - _getCollGasCompensation(statePre.userColl));
 
-        // just default values * BIMA_DECIMAL_PRECISION as no previous errors
+        // just defaulted values * BIMA_DECIMAL_PRECISION as no previous errors
         // and only 1 trove total (the one being liquidated)
         assertEq(stakedBTCTroveMgr.L_collateral(),
                  stakedBTCTroveMgr.defaultedCollateral() * BIMA_DECIMAL_PRECISION);

--- a/test/foundry/dao/AdminVotingTest.t.sol
+++ b/test/foundry/dao/AdminVotingTest.t.sol
@@ -155,6 +155,24 @@ contract AdminVotingTest is TestSetup {
                                adminVoting.getWeek()-1,
                                adminVoting.SET_GUARDIAN_PASSING_PCT(),
                                payload);
+
+        // change default passing percent to be higher than hard-coded
+        // setGuardian passing percent
+        uint256 higherPassingPct = adminVoting.SET_GUARDIAN_PASSING_PCT() + 1;
+        vm.prank(address(adminVoting));
+        adminVoting.setPassingPct(higherPassingPct);
+
+        // create a second setGuardian proposal
+        vm.warp(block.timestamp + adminVoting.MIN_TIME_BETWEEN_PROPOSALS() + 1);
+        vm.prank(users.user1);
+        proposalId = adminVoting.createNewProposal(users.user1, payload);
+
+        // verify it received higher default passing percent instead
+        // of lower hard-coded setGuardian passing percent
+        _verifyCreatedProposal(proposalId,
+                               adminVoting.getWeek()-1,
+                               higherPassingPct,
+                               payload);
     }
 
     function test_createNewProposal_withVotingWeight() public returns(uint256 proposalId) {

--- a/test/foundry/dao/EmissionScheduleTest.t.sol
+++ b/test/foundry/dao/EmissionScheduleTest.t.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.19;
 // test setup
 import {TestSetup} from "../TestSetup.sol";
 
+// dependencies
+import {BIMA_100_PCT} from "../../../contracts/dependencies/Constants.sol";
+
 contract EmissionScheduleTest is TestSetup {
 
     uint64 constant internal EMISSION_10_PCT = 1000;  // 10%
@@ -52,10 +55,10 @@ contract EmissionScheduleTest is TestSetup {
         uint64 emissionPct1
     ) external {
         // bound inputs
-        emissionPct4 = uint64(bound(emissionPct4, 0, MAX_PCT));
-        emissionPct3 = uint64(bound(emissionPct3, 0, MAX_PCT));
-        emissionPct2 = uint64(bound(emissionPct2, 0, MAX_PCT));
-        emissionPct1 = uint64(bound(emissionPct1, 0, MAX_PCT));
+        emissionPct4 = uint64(bound(emissionPct4, 0, BIMA_100_PCT));
+        emissionPct3 = uint64(bound(emissionPct3, 0, BIMA_100_PCT));
+        emissionPct2 = uint64(bound(emissionPct2, 0, BIMA_100_PCT));
+        emissionPct1 = uint64(bound(emissionPct1, 0, BIMA_100_PCT));
 
         // warp forward 5 weeks
         vm.warp(block.timestamp + 5 weeks);
@@ -113,10 +116,10 @@ contract EmissionScheduleTest is TestSetup {
     ) external {
         // bound inputs
         unallocatedTotal = bound(unallocatedTotal, 0, type(uint128).max);
-        emissionPct4 = uint64(bound(emissionPct4, 0, MAX_PCT));
-        emissionPct3 = uint64(bound(emissionPct3, 0, MAX_PCT));
-        emissionPct2 = uint64(bound(emissionPct2, 0, MAX_PCT));
-        emissionPct1 = uint64(bound(emissionPct1, 0, MAX_PCT));
+        emissionPct4 = uint64(bound(emissionPct4, 0, BIMA_100_PCT));
+        emissionPct3 = uint64(bound(emissionPct3, 0, BIMA_100_PCT));
+        emissionPct2 = uint64(bound(emissionPct2, 0, BIMA_100_PCT));
+        emissionPct1 = uint64(bound(emissionPct1, 0, BIMA_100_PCT));
 
         // warp forward 5 weeks
         vm.warp(block.timestamp + 5 weeks);
@@ -136,7 +139,7 @@ contract EmissionScheduleTest is TestSetup {
         (uint256 amount, uint256 lock) 
             = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
 
-        assertEq(amount, unallocatedTotal * emissionPct1 / MAX_PCT);
+        assertEq(amount, unallocatedTotal * emissionPct1 / BIMA_100_PCT);
 
         // lockWeeks reduced by 1 and storage updated
         assertEq(lock, savedLockWeeks - 1);
@@ -157,7 +160,7 @@ contract EmissionScheduleTest is TestSetup {
         (amount, lock) 
             = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
 
-        assertEq(amount, unallocatedTotal * emissionPct2 / MAX_PCT);
+        assertEq(amount, unallocatedTotal * emissionPct2 / BIMA_100_PCT);
 
         // lockWeeks reduced by 2 and storage updated
         assertEq(lock, savedLockWeeks - 2);
@@ -178,7 +181,7 @@ contract EmissionScheduleTest is TestSetup {
         (amount, lock) 
             = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
 
-        assertEq(amount, unallocatedTotal * emissionPct3 / MAX_PCT);
+        assertEq(amount, unallocatedTotal * emissionPct3 / BIMA_100_PCT);
 
         // lockWeeks reduced by 3 and storage updated
         assertEq(lock, savedLockWeeks - 3);
@@ -199,7 +202,7 @@ contract EmissionScheduleTest is TestSetup {
         (amount, lock) 
             = emissionSchedule.getTotalWeeklyEmissions(currentWeek, unallocatedTotal);
 
-        assertEq(amount, unallocatedTotal * emissionPct4 / MAX_PCT);
+        assertEq(amount, unallocatedTotal * emissionPct4 / BIMA_100_PCT);
 
         // lockWeeks reduced by 4 and storage updated
         assertEq(lock, savedLockWeeks - 4);
@@ -222,7 +225,7 @@ contract EmissionScheduleTest is TestSetup {
 
         // confirm it is using values from last week of schedule
         // since that was the last modification
-        assertEq(amount, unallocatedTotal * emissionPct4 / MAX_PCT);
+        assertEq(amount, unallocatedTotal * emissionPct4 / BIMA_100_PCT);
         assertEq(lock, savedLockWeeks - 4);
         assertEq(lock, emissionSchedule.lockWeeks());
         assertEq(emissionPct4, emissionSchedule.weeklyPct());

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -4,6 +4,9 @@ pragma solidity 0.8.19;
 // test setup
 import {TestSetup, IBabelVault, BabelVault, IIncentiveVoting, ITokenLocker, IEmissionReceiver, IRewards, MockEmissionReceiver, MockBoostDelegate, SafeCast} from "../TestSetup.sol";
 
+// dependencies
+import {BIMA_100_PCT} from "../../../contracts/dependencies/Constants.sol";
+
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
@@ -187,7 +190,7 @@ contract VaultTest is TestSetup {
         assertEq(babelVault.totalUpdateWeek(), systemWeek);
 
         // verify unallocated supply reduced by weekly emission percent
-        uint256 firstWeekEmissions = INIT_BAB_TKN_TOTAL_SUPPLY*INIT_ES_WEEKLY_PCT/MAX_PCT;
+        uint256 firstWeekEmissions = INIT_BAB_TKN_TOTAL_SUPPLY*INIT_ES_WEEKLY_PCT/BIMA_100_PCT;
         assertTrue(firstWeekEmissions > 0);
         assertEq(babelVault.unallocatedTotal(), initialUnallocated - firstWeekEmissions);
 
@@ -528,7 +531,7 @@ contract VaultTest is TestSetup {
         // bound fuzz inputs
         rewardAmount = bound(rewardAmount, 0, allocatedBalancePre);
         mockEmissionReceiver.setReward(rewardAmount);
-        maxFeePct = SafeCast.toUint16(bound(maxFeePct, 0, MAX_PCT));
+        maxFeePct = SafeCast.toUint16(bound(maxFeePct, 0, BIMA_100_PCT));
 
         // setup boost delegate
         vm.prank(mockBoostDelegateAddr);
@@ -559,7 +562,7 @@ contract VaultTest is TestSetup {
         assertEq(babelVault.allocated(mockEmissionReceiverAddr), allocatedBalancePre - rewardAmount);
 
         // calculate expected fee
-        expectedFeeAmount = rewardAmount * maxFeePct / MAX_PCT;
+        expectedFeeAmount = rewardAmount * maxFeePct / BIMA_100_PCT;
 
         // verify delegate has stored pending reward equal to fee
         assertEq(babelVault.getStoredPendingReward(mockBoostDelegateAddr), expectedFeeAmount);
@@ -680,7 +683,7 @@ contract VaultTest is TestSetup {
         // bound fuzz inputs
         rewardAmount = bound(rewardAmount, 0, allocatedBalancePre);
         mockEmissionReceiver.setReward(rewardAmount);
-        maxFeePct = SafeCast.toUint16(bound(maxFeePct, 0, MAX_PCT));
+        maxFeePct = SafeCast.toUint16(bound(maxFeePct, 0, BIMA_100_PCT));
 
         // setup boost delegate
         vm.prank(mockBoostDelegateAddr);
@@ -706,7 +709,7 @@ contract VaultTest is TestSetup {
         assertEq(babelVault.allocated(mockEmissionReceiverAddr), allocatedBalancePre - rewardAmount);
 
         // calculate expected fee
-        expectedFeeAmount = rewardAmount * maxFeePct / MAX_PCT;
+        expectedFeeAmount = rewardAmount * maxFeePct / BIMA_100_PCT;
 
         // verify delegate has stored pending reward equal to fee
         assertEq(babelVault.getStoredPendingReward(mockBoostDelegateAddr), expectedFeeAmount);
@@ -781,7 +784,7 @@ contract VaultTest is TestSetup {
         assertEq(babelVault.totalUpdateWeek(), systemWeek);
 
         // verify unallocated supply reduced by weekly emission percent
-        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/MAX_PCT;
+        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/BIMA_100_PCT;
         assertTrue(firstWeekEmissions > 0);
         assertEq(babelVault.unallocatedTotal(), initialUnallocated - firstWeekEmissions);
 
@@ -852,7 +855,7 @@ contract VaultTest is TestSetup {
         //    the amount disabled receivers would have received if enabled; in
         //    this case only 1 receiver so entire emissions get credited back
         //    to unallocated supply
-        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/MAX_PCT;
+        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/BIMA_100_PCT;
         assertTrue(firstWeekEmissions > 0);
         assertEq(babelVault.unallocatedTotal(), initialUnallocated);
 
@@ -912,7 +915,7 @@ contract VaultTest is TestSetup {
         assertEq(babelVault.totalUpdateWeek(), systemWeek);
 
         // verify unallocated supply reduced by weekly emission percent
-        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/MAX_PCT;
+        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/BIMA_100_PCT;
         assertTrue(firstWeekEmissions > 0);
         uint256 remainingUnallocated = initialUnallocated - firstWeekEmissions;
         assertEq(babelVault.unallocatedTotal(), remainingUnallocated);
@@ -993,7 +996,7 @@ contract VaultTest is TestSetup {
         assertEq(babelVault.totalUpdateWeek(), systemWeek);
 
         // verify unallocated supply reduced by weekly emission percent
-        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/MAX_PCT;
+        uint256 firstWeekEmissions = initialUnallocated*INIT_ES_WEEKLY_PCT/BIMA_100_PCT;
         assertTrue(firstWeekEmissions > 0);
         uint256 remainingUnallocated = initialUnallocated - firstWeekEmissions;
         assertEq(babelVault.unallocatedTotal(), remainingUnallocated);


### PR DESCRIPTION
Fixes for:
* H-3 Impossible to liquidate borrower when a TroveManager instance only has 1 active borrower
* H-4 Permanent loss of BabelToken if a disabled emissions receiver doesn't call Vault::allocateNewEmissions
* M-5 IncentiveVoting::unfreeze doesn't remove votes if a user has voted with unfrozen weight prior to freezing
* L-12 setGuardian proposals may incorrectly set lower passing percent if current default is greater than hard-coded value for guardian proposals
* L-13 Prevent panic from division by zero in BabelBase::_requireUserAcceptsFee
* L-14 TokenLocker::withdrawWithPenalty doesn't reset account bitfield when dust handling results in no remaining locked tokens