### PR TITLE
Lots of additional test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ forge coverage --no-match-contract TroveManagerSanityTest --no-match-coverage co
 
 # coverage detailed
 mkdir coverage
-forge coverage --no-match-contract TroveManagerSanityTest --no-match-coverage contracts/mock/ --report lcov --report-file coverage/fuzz.coverage.lcov
+forge coverage --no-match-contract TroveManagerSanityTest --no-match-coverage (contracts/mock/|test/) --report lcov --report-file coverage/fuzz.coverage.lcov
 genhtml coverage/fuzz.coverage.lcov -o coverage
 # open coverage/index.html in your browser and navigate to the relevant source file to see line-by-line execution records
 ```

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Run unit tests and coverage report with:
 forge test --no-match-contract TroveManagerSanityTest
 
 # coverage summary
-forge coverage --no-match-contract TroveManagerSanityTest --no-match-coverage contracts/mock/
+forge coverage --no-match-contract TroveManagerSanityTest --no-match-coverage "(contracts/mock/|test/)"
 
 # coverage detailed
 mkdir coverage
-forge coverage --no-match-contract TroveManagerSanityTest --no-match-coverage (contracts/mock/|test/) --report lcov --report-file coverage/fuzz.coverage.lcov
+forge coverage --no-match-contract TroveManagerSanityTest --no-match-coverage "(contracts/mock/|test/)" --report lcov --report-file coverage/fuzz.coverage.lcov
 genhtml coverage/fuzz.coverage.lcov -o coverage
 # open coverage/index.html in your browser and navigate to the relevant source file to see line-by-line execution records
 ```

--- a/contracts/dao/AllocationVesting.sol
+++ b/contracts/dao/AllocationVesting.sol
@@ -79,6 +79,16 @@ contract AllocationVesting is DelegatedOps, Ownable {
         maxTotalPreclaimPct = maxTotalPreclaimPct_;
     }
 
+
+    /**
+     *
+     * @notice Returns claimed amount
+     * @param account account to check
+     */
+    function getClaimed(address account) external view returns(uint256 claimed) {
+        claimed = allocations[account].claimed;
+    }
+
     /**
      *
      * @notice Set allocations and starts vesting

--- a/contracts/dao/InterimAdmin.sol
+++ b/contracts/dao/InterimAdmin.sol
@@ -88,13 +88,31 @@ contract InterimAdmin is Ownable {
         canExecuteAfter = proposal.canExecuteAfter;
         executed = proposal.processed;
     }
+    function getProposalCreatedAt(uint256 id) external view returns(uint256 createdAt) {
+        createdAt = proposalData[id].createdAt;
+    }
+    function getProposalCanExecuteAfter(uint256 id) external view returns(uint256 canExecuteAfter) {
+        canExecuteAfter = proposalData[id].canExecuteAfter;
+    }
+    function getProposalExecuted(uint256 id) external view returns(bool executed) {
+        executed = proposalData[id].processed;
+    }
+    function getProposalCanExecute(uint256 id) external view returns(bool canExecute) {
+        Proposal memory proposal = proposalData[id];
+        canExecute = (!proposal.processed &&
+            proposal.canExecuteAfter < block.timestamp &&
+            proposal.canExecuteAfter + MAX_TIME_TO_EXECUTION > block.timestamp);
+    }
+    function getProposalPayload(uint256 id) external view returns(Action[] memory payload) {
+        payload = proposalPayloads[id];
+    }
 
     /**
         @notice Create a new proposal
         @param payload Tuple of [(target address, calldata), ... ] to be
                        executed if the proposal is passed.
      */
-    function createNewProposal(Action[] calldata payload) external onlyOwner {
+    function createNewProposal(Action[] calldata payload) external onlyOwner returns(uint256 proposalId) {
         // enforce >=1 payload
         require(payload.length > 0, "Empty payload");
         
@@ -115,7 +133,7 @@ contract InterimAdmin is Ownable {
         }
 
         // fetch next proposal id
-        uint256 proposalId = proposalData.length;
+        proposalId = proposalData.length;
 
         // save new proposal data
         proposalData.push(

--- a/contracts/interfaces/IVault.sol
+++ b/contracts/interfaces/IVault.sol
@@ -87,6 +87,8 @@ interface IBabelVault is IBabelOwnable, ISystemStart {
 
     function isReceiverActive(uint256 id) external view returns(bool isActive);
 
+    function isBoostDelegatedEnabled(address account) external view returns(bool isEnabled);
+
     function lockWeeks() external view returns (uint64);
 
     function locker() external view returns (ITokenLocker);

--- a/contracts/mock/MockOracle.sol
+++ b/contracts/mock/MockOracle.sol
@@ -27,6 +27,12 @@ contract MockOracle is IAggregatorV3Interface {
         answeredInRound = _answeredInRound;
     }
 
+    function refresh() external {
+        ++roundId;
+        ++answeredInRound;
+        updatedAt = block.timestamp;
+    }
+
     function decimals() external pure returns (uint8) {
         return 8;
     }

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -166,6 +166,8 @@ contract TestSetup is Test {
                             18, // sharePriceDecimals
                             false //_isEthIndexed
                             );
+        assertEq(priceFeed.owner(), users.owner);
+        assertEq(priceFeed.guardian(), users.guardian);
 
         // FeeReceiver
         feeReceiver = new FeeReceiver(addresses.core); ++addresses.nonce;

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -300,8 +300,8 @@ contract TestSetup is Test {
         // create EmissionSchedule
         uint64[2][] memory scheduledWeeklyPct;
         emissionSchedule = new EmissionSchedule(address(babelCore), 
-                                                IIncentiveVoting(address(incentiveVoting)),
-                                                IBabelVault(address(babelVault)),
+                                                incentiveVoting,
+                                                babelVault,
                                                 INIT_ES_LOCK_WEEKS,
                                                 INIT_ES_LOCK_DECAY_WEEKS,
                                                 INIT_ES_WEEKLY_PCT,
@@ -314,7 +314,7 @@ contract TestSetup is Test {
 
         // create BoostCalculator
         boostCalc = new BoostCalculator(address(babelCore),
-                                        ITokenLocker(address(tokenLocker)),
+                                        tokenLocker,
                                         INIT_BS_GRACE_WEEKS);
 
         // note: the hardhat script had some post deloyment actions
@@ -377,7 +377,7 @@ contract TestSetup is Test {
         assertEq(babelVault.lockWeeks(), INIT_VLT_LOCK_WEEKS);
     }
 
-    function _vaultSetupAndLockTokens(uint256 user1Allocation) internal returns (uint256 initialUnallocated) {
+    function _vaultSetupAndLockTokens(uint256 user1Allocation, bool lock) internal returns (uint256 initialUnallocated) {
         // setup the vault to get BabelTokens which are used for voting
         uint128[] memory _fixedInitialAmounts;
         IBabelVault.InitialAllowance[] memory initialAllowances 
@@ -423,16 +423,18 @@ contract TestSetup is Test {
         initialUnallocated = babelVault.unallocatedTotal();
         assertEq(initialUnallocated, INIT_BAB_TKN_TOTAL_SUPPLY - user1Allocation);
 
-        // receiver locks up their tokens to get voting weight
-        vm.prank(users.user1);
-        tokenLocker.lock(users.user1, user1Allocation/INIT_LOCK_TO_TOKEN_RATIO, 52);
+        if(lock) {
+            // receiver locks up their tokens to get voting weight
+            vm.prank(users.user1);
+            tokenLocker.lock(users.user1, user1Allocation/INIT_LOCK_TO_TOKEN_RATIO, 52);
 
-        // verify receiver balance after lock; calculated this way because of how
-        // lock amount gets scaled down by INIT_LOCK_TO_TOKEN_RATIO then for token
-        // transfer scales it up by INIT_LOCK_TO_TOKEN_RATIO
-        uint256 users1TokensAfterLock = user1Allocation -
-                                        (user1Allocation/INIT_LOCK_TO_TOKEN_RATIO)*INIT_LOCK_TO_TOKEN_RATIO;
-        assertEq(babelToken.balanceOf(users.user1), users1TokensAfterLock);
+            // verify receiver balance after lock; calculated this way because of how
+            // lock amount gets scaled down by INIT_LOCK_TO_TOKEN_RATIO then for token
+            // transfer scales it up by INIT_LOCK_TO_TOKEN_RATIO
+            uint256 users1TokensAfterLock = user1Allocation -
+                                            (user1Allocation/INIT_LOCK_TO_TOKEN_RATIO)*INIT_LOCK_TO_TOKEN_RATIO;
+            assertEq(babelToken.balanceOf(users.user1), users1TokensAfterLock);
+        }
     }
 
     function _vaultRegisterReceiver(address receiverAddr, uint256 count) internal returns(uint256 firstReceiverId) {

--- a/test/foundry/core/BabelCoreTest.t.sol
+++ b/test/foundry/core/BabelCoreTest.t.sol
@@ -87,7 +87,7 @@ contract BabelCoreTest is TestSetup {
     }
 
     function test_acceptTransferOwnership_failsNotNewPendingOwner() external {
-        address newPendingOwner = test_commitTransferOwnership();
+        test_commitTransferOwnership();
 
         vm.expectRevert("Only new owner");
         babelCore.acceptTransferOwnership();
@@ -120,7 +120,7 @@ contract BabelCoreTest is TestSetup {
     }
 
     function test_revokeTransferOwnership() external {
-        address newPendingOwner = test_commitTransferOwnership();
+        test_commitTransferOwnership();
 
         vm.prank(users.owner);
         babelCore.revokeTransferOwnership();

--- a/test/foundry/core/BabelCoreTest.t.sol
+++ b/test/foundry/core/BabelCoreTest.t.sol
@@ -38,4 +38,95 @@ contract BabelCoreTest is TestSetup {
         vm.prank(users.user1);
         babelCore.setPaused(false);
     }
+
+    function test_setFeeReceiver_failsNotOwner() external {
+        vm.expectRevert("Only owner");
+        babelCore.setFeeReceiver(address(0));
+    }
+
+    function test_setFeeReceiver() external {
+        vm.prank(users.owner);
+        babelCore.setFeeReceiver(address(0));
+        assertEq(babelCore.feeReceiver(), address(0));
+    }
+
+    function test_setPriceFeed_failsNotOwner() external {
+        vm.expectRevert("Only owner");
+        babelCore.setPriceFeed(address(0));
+    }
+
+    function test_setPriceFeed() external {
+        vm.prank(users.owner);
+        babelCore.setPriceFeed(address(0));
+        assertEq(babelCore.priceFeed(), address(0));
+    }
+
+    function test_setGuardian_failsNotOwner() external {
+        vm.expectRevert("Only owner");
+        babelCore.setGuardian(address(0));
+    }
+
+    function test_setGuardian() external {
+        vm.prank(users.owner);
+        babelCore.setGuardian(address(0));
+        assertEq(babelCore.guardian(), address(0));
+    }
+
+    function test_commitTransferOwnership_failsNotOwner() external {
+        vm.expectRevert("Only owner");
+        babelCore.commitTransferOwnership(address(0));
+    }
+
+    function test_commitTransferOwnership() public returns(address newPendingOwner) {
+        newPendingOwner = address(0x9876);
+        vm.prank(users.owner);
+        babelCore.commitTransferOwnership(newPendingOwner);
+
+        assertEq(babelCore.pendingOwner(), newPendingOwner);
+        assertEq(babelCore.ownershipTransferDeadline(), block.timestamp + babelCore.OWNERSHIP_TRANSFER_DELAY());
+    }
+
+    function test_acceptTransferOwnership_failsNotNewPendingOwner() external {
+        address newPendingOwner = test_commitTransferOwnership();
+
+        vm.expectRevert("Only new owner");
+        babelCore.acceptTransferOwnership();
+    }
+
+    function test_acceptTransferOwnership_failsTransferDeadlineNotElapsed() external {
+        address newPendingOwner = test_commitTransferOwnership();
+
+        vm.expectRevert("Deadline not passed");
+        vm.prank(newPendingOwner);
+        babelCore.acceptTransferOwnership();
+    }
+
+    function test_acceptTransferOwnership() external {
+        address newPendingOwner = test_commitTransferOwnership();
+
+        vm.warp(babelCore.ownershipTransferDeadline());
+
+        vm.prank(newPendingOwner);
+        babelCore.acceptTransferOwnership();
+
+        assertEq(babelCore.owner(), newPendingOwner);
+        assertEq(babelCore.pendingOwner(), address(0));
+        assertEq(babelCore.ownershipTransferDeadline(), 0);
+    }
+
+    function test_revokeTransferOwnership_failsNotOwner() external {
+        vm.expectRevert("Only owner");
+        babelCore.revokeTransferOwnership();
+    }
+
+    function test_revokeTransferOwnership() external {
+        address newPendingOwner = test_commitTransferOwnership();
+
+        vm.prank(users.owner);
+        babelCore.revokeTransferOwnership();
+
+        assertEq(babelCore.owner(), users.owner);
+        assertEq(babelCore.pendingOwner(), address(0));
+        assertEq(babelCore.ownershipTransferDeadline(), 0);
+    }
 }

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -940,7 +940,7 @@ contract BorrowerOperationsTest is StabilityPoolTest {
 
     function test_claimReward_someTroveManagerDebtRewardsLost() external {
         // setup vault giving user1 half supply to lock for voting power
-        uint256 initialUnallocated = _vaultSetupAndLockTokens(INIT_BAB_TKN_TOTAL_SUPPLY/2);
+        uint256 initialUnallocated = _vaultSetupAndLockTokens(INIT_BAB_TKN_TOTAL_SUPPLY/2, true);
 
         // owner registers TroveManager for vault emission rewards
         vm.prank(users.owner);

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -1134,13 +1134,19 @@ contract BorrowerOperationsTest is StabilityPoolTest {
 
     // used to store relevant state before tests for verification afterwards
     struct TroveManagerState {
+        uint256 defaultedDebt;
+        uint256 defaultedCollateral;
         uint256 totalActiveDebt;
+        uint256 totalActiveCollateral;
         uint256 interestPayable;
         uint256 activeInterestIndex;
         uint256 lastActiveIndexUpdate;
     }
     function _getTroveManagerState() internal view returns(TroveManagerState memory state) {
+        state.defaultedDebt = stakedBTCTroveMgr.defaultedDebt();
+        state.defaultedCollateral = stakedBTCTroveMgr.defaultedCollateral();
         state.totalActiveDebt = stakedBTCTroveMgr.getTotalActiveDebt();
+        state.totalActiveCollateral = stakedBTCTroveMgr.getTotalActiveCollateral();
         state.interestPayable = stakedBTCTroveMgr.interestPayable();
         state.activeInterestIndex = stakedBTCTroveMgr.activeInterestIndex();
         state.lastActiveIndexUpdate = stakedBTCTroveMgr.lastActiveIndexUpdate();

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -10,6 +10,8 @@ import {BabelMath} from "../../../contracts/dependencies/BabelMath.sol";
 import {BIMA_100_PCT} from "../../../contracts/dependencies/Constants.sol";
 import {ITroveManager, IERC20} from "../../../contracts/interfaces/ITroveManager.sol";
 
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+
 // also tests TroveManager since BorrowerOps and TroveManager are very closely linked
 contract BorrowerOperationsTest is StabilityPoolTest {
 
@@ -19,6 +21,12 @@ contract BorrowerOperationsTest is StabilityPoolTest {
     uint256 internal minDebt;
 
     uint256 constant internal OWNER_TROVE_COLLATERAL = 1e18; // 1BTC
+
+    // non-public copied from TroveManager.sol
+    uint256 constant internal TM_INTEREST_PRECISION = 1e27;
+    uint256 constant internal TM_SECONDS_IN_YEAR = 365 days;
+    uint256 constant internal VOLUME_MULTIPLIER = 1e20;
+
 
     // since owner opens an initial trove, don't want to revert
     // during fuzz tests for trying to open more debt than allowed
@@ -45,6 +53,23 @@ contract BorrowerOperationsTest is StabilityPoolTest {
         // since liquidation doesn't work by design if only 1 trove
         _openTrove(users.owner, OWNER_TROVE_COLLATERAL, INIT_MIN_NET_DEBT);
         assertEq(stakedBTCTroveMgr.getTroveOwnersCount(), 1);
+
+        // verify view functions return correct data for owner trove
+        assertEq(stakedBTCTroveMgr.getTroveStake(users.owner), OWNER_TROVE_COLLATERAL);
+        
+        (uint256 week, uint256 day) = stakedBTCTroveMgr.getWeekAndDay();
+        uint32[7] memory mints = stakedBTCTroveMgr.getTotalMints(week);
+        assertEq(mints[day], INIT_MIN_NET_DEBT / VOLUME_MULTIPLIER);
+
+        assertEq(stakedBTCTroveMgr.getTroveFromTroveOwnersArray(0), users.owner);
+
+        (uint256 coll, uint256 debt) = stakedBTCTroveMgr.getTroveCollAndDebt(users.owner);
+        assertEq(coll, OWNER_TROVE_COLLATERAL);
+        assertEq(debt, INIT_MIN_NET_DEBT + INIT_GAS_COMPENSATION);
+
+        assertEq(stakedBTCTroveMgr.getEntireSystemColl(), OWNER_TROVE_COLLATERAL);
+
+        assertFalse(stakedBTCTroveMgr.hasPendingRewards(users.owner));
 
         minCollateral = 3e17;
         maxCollateral = 1_000_000e18 - OWNER_TROVE_COLLATERAL;
@@ -763,6 +788,98 @@ contract BorrowerOperationsTest is StabilityPoolTest {
         assertEq(statePost.sysBalances.prices[0], balancesPre.prices[0]);
     }
 
+    function test_redeemCollateral_closeOneTrovePartialRedeemOther() external {
+        // fast forward time to after bootstrap period
+        vm.warp(stakedBTCTroveMgr.systemDeploymentTime() + stakedBTCTroveMgr.BOOTSTRAP_PERIOD());
+
+        // update price oracle response to prevent stale revert
+        mockOracle.setResponse(mockOracle.roundId() + 1,
+                               mockOracle.answer(),
+                               mockOracle.startedAt(),
+                               block.timestamp,
+                               mockOracle.answeredInRound() + 1);
+
+        // user1 opens a trove with 5 BTC collateral for their max borrowing power
+        uint256 collateralAmount = 5e18;
+
+        uint256 debtAmountMax
+            = ((collateralAmount * _getScaledOraclePrice() / borrowerOps.CCR())
+              - INIT_GAS_COMPENSATION);
+
+        _openTrove(users.user1, collateralAmount, debtAmountMax);
+
+        // user2 opens a trove with 1 BTC collateral for their max borrowing power
+        _openTrove(users.user2, collateralAmount, debtAmountMax);
+
+        // mint user3 enough debt tokens such that 1 trove will be closed
+        // and a partial redemption will occur from another trove
+        uint256 debtToSend = debtAmountMax + debtAmountMax/2;
+
+        vm.prank(address(borrowerOps));
+        debtToken.mint(users.user3, debtToSend);
+        assertEq(debtToken.balanceOf(users.user3), debtToSend);
+        assertEq(stakedBTC.balanceOf(users.user3), 0);
+
+        // save system balances prior to redemption
+        IBorrowerOperations.SystemBalances memory balancesPre = borrowerOps.fetchBalances();
+        assertEq(balancesPre.collaterals.length, 1);
+        assertEq(balancesPre.collaterals.length, balancesPre.debts.length);
+        assertEq(balancesPre.collaterals.length, balancesPre.prices.length);
+
+        // user3 exchanges their debt tokens for collateral
+        uint256 maxFeePercent = stakedBTCTroveMgr.maxRedemptionFee();
+
+        vm.prank(users.user3);
+        stakedBTCTroveMgr.redeemCollateral(debtToSend,
+                                           users.user1, address(0), address(0), 5833302083567706, 0,
+                                           maxFeePercent);
+
+        // verify user3 has no debt tokens remaining
+        assertEq(debtToken.balanceOf(users.user3), 0);
+
+        // verify user3 received some collateral tokens
+        uint256 user3ReceivedCollateral = stakedBTC.balanceOf(users.user3);
+        assertEq(user3ReceivedCollateral, 2071335111546853914);
+
+        // verify user1's trove was closed by the redemption
+        assertEq(uint8(stakedBTCTroveMgr.getTroveStatus(users.user1)),
+                 uint8(ITroveManager.Status.closedByRedemption));
+
+        // verify user2's trove is still active
+        assertEq(uint8(stakedBTCTroveMgr.getTroveStatus(users.user2)),
+                 uint8(ITroveManager.Status.active));
+
+        // user1 claims the remaining collateral
+        vm.prank(users.user1);
+        stakedBTCTroveMgr.claimCollateral(users.user1);
+
+        // get user1 state
+        BorrowerOpsState memory statePost = _getBorrowerOpsState(users.user1);
+
+        // verify trove count decreased by 1
+        assertEq(statePost.troveOwnersCount, 2);
+
+        // verify user1 received correct remaining collateral
+        assertEq(statePost.userSBTCBal, 2777794444444444445);
+
+        // verify user1 has their original debt tokens since user3's debt tokens
+        // were used to close the trove
+        assertEq(statePost.userDebtTokenBal, debtAmountMax);
+
+        // get user2 state
+        statePost = _getBorrowerOpsState(users.user2);
+
+        // verify user2 has no collateral as their trove was not closed
+        assertEq(statePost.userSBTCBal, 0);
+        // verify user2 debt unchanged
+        assertEq(statePost.userDebtTokenBal, debtAmountMax);
+
+        // user2 open trove has its collateral reduced
+        (uint256 coll, uint256 debt) = stakedBTCTroveMgr.getTroveCollAndDebt(users.user2);
+        assertEq(coll, 3888897222222222223);
+        // and its debt was approximately halved
+        assertEq(debt, 66667166666666666666667);
+    }
 
     function test_claimReward_someTroveManagerDebtRewardsLost() external {
         // setup vault giving user1 half supply to lock for voting power
@@ -909,5 +1026,173 @@ contract BorrowerOperationsTest is StabilityPoolTest {
 
         uint256 compositeDebt = borrowerOps.getCompositeDebt(debt);
         assertEq(compositeDebt, debt + borrowerOps.DEBT_GAS_COMPENSATION());
+    }
+
+    function test_setPaused_guardianCanPauseNotUnpause() external {
+        vm.prank(users.guardian);
+        stakedBTCTroveMgr.setPaused(true);
+
+        assertTrue(stakedBTCTroveMgr.paused());
+
+        vm.expectRevert("Unauthorized");
+        vm.prank(users.guardian);
+        stakedBTCTroveMgr.setPaused(false);
+    }
+
+    function test_setPaused_ownerCanPauseUnpause() external {
+        vm.prank(users.owner);
+        stakedBTCTroveMgr.setPaused(true);
+
+        assertTrue(stakedBTCTroveMgr.paused());
+
+        vm.prank(users.owner);
+        stakedBTCTroveMgr.setPaused(false);
+
+        assertFalse(stakedBTCTroveMgr.paused());
+    }
+
+    function test_setPaused_failNormalUser() external {
+        vm.expectRevert("Unauthorized");
+        vm.prank(users.user1);
+        stakedBTCTroveMgr.setPaused(true);
+
+        vm.expectRevert("Unauthorized");
+        vm.prank(users.user1);
+        stakedBTCTroveMgr.setPaused(false);
+    }
+
+    function test_setPriceFeed_failNotOwner() external {
+        vm.expectRevert("Only owner");
+        stakedBTCTroveMgr.setPriceFeed(address(0x1234));
+    }
+
+    function test_setPriceFeed() external {
+        vm.prank(users.owner);
+        stakedBTCTroveMgr.setPriceFeed(address(0x1234));
+
+        assertEq(address(stakedBTCTroveMgr.priceFeed()), address(0x1234));
+    }
+
+    function test_setParameters_failNotOwner() external {
+        IFactory.DeploymentParams memory params = IFactory.DeploymentParams({
+            minuteDecayFactor : 999037758833783000,
+            redemptionFeeFloor: INIT_REDEMPTION_FEE_FLOOR,
+            maxRedemptionFee: INIT_MAX_REDEMPTION_FEE,
+            borrowingFeeFloor: INIT_BORROWING_FEE_FLOOR,
+            maxBorrowingFee: INIT_MAX_BORROWING_FEE,
+            interestRateInBps: INIT_INTEREST_RATE_BPS,
+            maxDebt: INIT_MAX_DEBT,
+            MCR: INIT_MCR
+        });
+
+        vm.expectRevert("Only owner");
+        stakedBTCTroveMgr.setParameters(params.minuteDecayFactor,
+                                        params.redemptionFeeFloor,
+                                        params.maxRedemptionFee,
+                                        params.borrowingFeeFloor,
+                                        params.maxBorrowingFee,
+                                        params.interestRateInBps,
+                                        params.maxDebt,
+                                        params.MCR);
+    }
+
+    function _setInterestRate(uint256 newRateInBps) internal {
+        IFactory.DeploymentParams memory params = IFactory.DeploymentParams({
+            minuteDecayFactor : 999037758833783000,
+            redemptionFeeFloor: INIT_REDEMPTION_FEE_FLOOR,
+            maxRedemptionFee: INIT_MAX_REDEMPTION_FEE,
+            borrowingFeeFloor: INIT_BORROWING_FEE_FLOOR,
+            maxBorrowingFee: INIT_MAX_BORROWING_FEE,
+            interestRateInBps: newRateInBps,
+            maxDebt: INIT_MAX_DEBT,
+            MCR: INIT_MCR
+        });
+
+        vm.prank(users.owner);
+        stakedBTCTroveMgr.setParameters(params.minuteDecayFactor,
+                                        params.redemptionFeeFloor,
+                                        params.maxRedemptionFee,
+                                        params.borrowingFeeFloor,
+                                        params.maxBorrowingFee,
+                                        params.interestRateInBps,
+                                        params.maxDebt,
+                                        params.MCR);
+
+        assertEq(stakedBTCTroveMgr.lastActiveIndexUpdate(), block.timestamp);
+
+        uint256 expectedNewRate = (TM_INTEREST_PRECISION * params.interestRateInBps) /
+                                  (BIMA_100_PCT * TM_SECONDS_IN_YEAR);
+
+        assertEq(stakedBTCTroveMgr.interestRate(), expectedNewRate);
+    }
+
+    function test_setParameters(uint256 newRateInBps) external {
+        newRateInBps = bound(newRateInBps, 1, stakedBTCTroveMgr.MAX_INTEREST_RATE_IN_BPS());
+
+        _setInterestRate(newRateInBps);
+    }
+
+    // used to store relevant state before tests for verification afterwards
+    struct TroveManagerState {
+        uint256 totalActiveDebt;
+        uint256 interestPayable;
+        uint256 activeInterestIndex;
+        uint256 lastActiveIndexUpdate;
+    }
+    function _getTroveManagerState() internal view returns(TroveManagerState memory state) {
+        state.totalActiveDebt = stakedBTCTroveMgr.getTotalActiveDebt();
+        state.interestPayable = stakedBTCTroveMgr.interestPayable();
+        state.activeInterestIndex = stakedBTCTroveMgr.activeInterestIndex();
+        state.lastActiveIndexUpdate = stakedBTCTroveMgr.lastActiveIndexUpdate();
+    }
+
+    function test_accrueActiveInterests(uint256 rateInBps) external {
+        rateInBps = bound(rateInBps, 1, stakedBTCTroveMgr.MAX_INTEREST_RATE_IN_BPS());
+
+        _setInterestRate(rateInBps);
+
+        uint256 newInterestRate = stakedBTCTroveMgr.interestRate();
+
+        // save pre state
+        TroveManagerState memory statePre = _getTroveManagerState();
+
+        // fast forward 1 week
+        uint256 elapsedTime = 1 weeks;
+        vm.warp(block.timestamp + elapsedTime);
+
+        // calculate expected parameters
+        uint256 interestFactor = elapsedTime * newInterestRate;
+        uint256 currentInterestIndex = statePre.activeInterestIndex +
+                                       Math.mulDiv(statePre.activeInterestIndex, interestFactor, TM_INTEREST_PRECISION);
+        uint256 newInterest = Math.mulDiv(statePre.totalActiveDebt, interestFactor, TM_INTEREST_PRECISION);
+
+        // test these view functions correctly factor in interest payments
+        // even though the call to _accrueActiveInterests has not yet occurred
+        assertEq(stakedBTCTroveMgr.getEntireSystemDebt(), statePre.totalActiveDebt + newInterest);
+        assertEq(stakedBTCTroveMgr.getTotalActiveDebt(), statePre.totalActiveDebt + newInterest);
+
+        // trigger _accrueActiveInterests
+        vm.prank(address(liquidationMgr));
+        stakedBTCTroveMgr.updateBalances();
+
+        // save post state
+        TroveManagerState memory statePost = _getTroveManagerState();
+
+        // verify new interest added to total active debt and interest payable
+        assertEq(statePost.totalActiveDebt, statePre.totalActiveDebt + newInterest);
+        assertEq(statePost.interestPayable, statePre.interestPayable + newInterest);
+
+        // verify active interest index updated
+        assertNotEq(currentInterestIndex, statePre.activeInterestIndex);
+        assertEq(statePost.activeInterestIndex, currentInterestIndex);
+        
+        // verify active index update timestamp updated
+        assertTrue(statePost.lastActiveIndexUpdate > statePre.lastActiveIndexUpdate);
+        assertEq(statePost.lastActiveIndexUpdate, block.timestamp);
+
+        // verify interest payable can be collected
+        uint256 feeReceiverDebtTokenBalPre = debtToken.balanceOf(address(feeReceiver));
+        stakedBTCTroveMgr.collectInterests();
+        assertEq(debtToken.balanceOf(address(feeReceiver)), feeReceiverDebtTokenBalPre + newInterest);
     }
 }

--- a/test/foundry/core/DebtTokenTest.t.sol
+++ b/test/foundry/core/DebtTokenTest.t.sol
@@ -4,7 +4,9 @@ pragma solidity 0.8.19;
 // test setup
 import {TestSetup, DebtToken} from "../TestSetup.sol";
 
-contract DebtTokenTest is TestSetup {
+import {IERC3156FlashBorrower} from "@openzeppelin/contracts/interfaces/IERC3156FlashBorrower.sol";
+
+contract DebtTokenTest is IERC3156FlashBorrower, TestSetup {
 
     function test_flashLoanFee() external {
         // entire supply initially available to borrow
@@ -27,6 +29,28 @@ contract DebtTokenTest is TestSetup {
         borrowAmount = 1111;
         vm.expectRevert("ERC20FlashMint: amount too small");
         debtToken.flashFee(borrowAmount);
+    }
 
+    function test_flashLoan(uint256 amount) external {
+        amount = bound(amount, 1e18, 1_000_000_000_000e18);
+
+        debtToken.flashLoan(this, amount, bytes(""));
+    }
+
+    function onFlashLoan(
+        address /*initiator*/,
+        address /*token*/,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata /*data*/
+    ) external returns (bytes32 returnVal) {
+        returnVal = keccak256("ERC3156FlashBorrower.onFlashLoan");
+
+        // mint ourselves the fee
+        vm.prank(address(borrowerOps));
+        debtToken.mint(address(this), fee);
+
+        // approve debt token contract to take amount + fee
+        debtToken.approve(address(debtToken), amount+fee);
     }
 }

--- a/test/foundry/core/DebtTokenTest.t.sol
+++ b/test/foundry/core/DebtTokenTest.t.sol
@@ -3,18 +3,22 @@ pragma solidity 0.8.19;
 
 // test setup
 import {TestSetup, DebtToken} from "../TestSetup.sol";
+import {BIMA_100_PCT} from "../../../contracts/dependencies/Constants.sol";
 
 import {IERC3156FlashBorrower} from "@openzeppelin/contracts/interfaces/IERC3156FlashBorrower.sol";
 
 contract DebtTokenTest is IERC3156FlashBorrower, TestSetup {
+
+    uint256 internal constant MIN_AMOUNT = 1e18;
+    uint256 internal constant MAX_AMOUNT = 1_000_000_000_000e18;
 
     function test_flashLoanFee() external {
         // entire supply initially available to borrow
         assertEq(debtToken.maxFlashLoan(), type(uint256).max);
 
         // expected fee for borrowing 1e18
-        uint256 borrowAmount = 1e18;
-        uint256 expectedFee  = borrowAmount * debtToken.FLASH_LOAN_FEE() / 10000;
+        uint256 borrowAmount = MIN_AMOUNT;
+        uint256 expectedFee  = borrowAmount * debtToken.FLASH_LOAN_FEE() / BIMA_100_PCT;
 
         // fee should be > 0
         assertTrue(expectedFee > 0);
@@ -32,9 +36,93 @@ contract DebtTokenTest is IERC3156FlashBorrower, TestSetup {
     }
 
     function test_flashLoan(uint256 amount) external {
-        amount = bound(amount, 1e18, 1_000_000_000_000e18);
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
 
         debtToken.flashLoan(this, amount, bytes(""));
+    }
+
+    function test_transfer_failToZeroAddress(uint256 amount) external {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+        
+        vm.prank(address(borrowerOps));
+        debtToken.mint(address(this), amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the Debt token contract or the zero address");
+        debtToken.transfer(address(0), amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the Debt token contract or the zero address");
+        debtToken.transferFrom(address(this), address(0), amount);
+    }
+
+    function test_transfer_failToDebtTokenContractAddress(uint256 amount) external {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+        
+        vm.prank(address(borrowerOps));
+        debtToken.mint(address(this), amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the Debt token contract or the zero address");
+        debtToken.transfer(address(debtToken), amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the Debt token contract or the zero address");
+        debtToken.transferFrom(address(this), address(debtToken), amount);
+    }
+
+    function test_transfer_failToProtocolContractAddresses(uint256 amount) external {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+        
+        vm.prank(address(borrowerOps));
+        debtToken.mint(address(this), amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the StabilityPool, TroveManager or BorrowerOps");
+        debtToken.transfer(address(stabilityPool), amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the StabilityPool, TroveManager or BorrowerOps");
+        debtToken.transferFrom(address(this), address(stabilityPool), amount);
+
+        address stakedBTCTroveMgrAddr = factory.troveManagers(0);
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the StabilityPool, TroveManager or BorrowerOps");
+        debtToken.transfer(stakedBTCTroveMgrAddr, amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the StabilityPool, TroveManager or BorrowerOps");
+        debtToken.transferFrom(address(this), stakedBTCTroveMgrAddr, amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the StabilityPool, TroveManager or BorrowerOps");
+        debtToken.transfer(address(borrowerOps), amount);
+
+        vm.expectRevert("Debt: Cannot transfer tokens directly to the StabilityPool, TroveManager or BorrowerOps");
+        debtToken.transferFrom(address(this), address(borrowerOps), amount);
+    }
+    
+    function test_transfer(uint256 amount) external {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        vm.prank(address(borrowerOps));
+        debtToken.mint(address(this), amount);
+
+        assertTrue(debtToken.transfer(users.user2, amount));
+
+        assertEq(debtToken.balanceOf(address(this)), 0);
+        assertEq(debtToken.balanceOf(users.user2), amount);
+    }
+
+    function test_transferFrom(uint256 amount) external {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        vm.prank(address(borrowerOps));
+        debtToken.mint(address(this), amount);
+
+        debtToken.approve(address(this), amount);
+        assertTrue(debtToken.transferFrom(address(this), users.user2, amount));
+
+        assertEq(debtToken.balanceOf(address(this)), 0);
+        assertEq(debtToken.balanceOf(users.user2), amount);
+    }
+
+    function test_transfer_failLackOfFunds(uint256 amount) external {
+        amount = bound(amount, MIN_AMOUNT, MAX_AMOUNT);
+
+        vm.expectRevert("ERC20: transfer amount exceeds balance");
+        debtToken.transfer(users.user2, amount);
     }
 
     function onFlashLoan(

--- a/test/foundry/core/FactoryTest.t.sol
+++ b/test/foundry/core/FactoryTest.t.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+// test setup
+import {TestSetup} from "../TestSetup.sol";
+
+contract FactoryTest is TestSetup {
+    function test_setImplementations_failNotOwner() external {
+        vm.expectRevert("Only owner");
+        factory.setImplementations(address(0), address(0));
+    }
+
+    function test_setImplementations() external {
+        vm.prank(users.owner);
+        factory.setImplementations(address(0x1234), address(0x2345));
+
+        assertEq(factory.troveManagerImpl(), address(0x1234));
+        assertEq(factory.sortedTrovesImpl(), address(0x2345));
+    }
+}

--- a/test/foundry/core/LiquidationManagerTest.t.sol
+++ b/test/foundry/core/LiquidationManagerTest.t.sol
@@ -490,6 +490,7 @@ contract LiquidationManagerTest is BorrowerOperationsTest {
 
         // sanity checks to ensure specific liquidation code called using `_tryLiquidateWithCap`
         assertTrue(TCR < borrowerOps.CCR());
+        assertTrue(borrowerOps.checkRecoveryMode(TCR));
         assertTrue(userICR < TCR);
 
         // save previous state

--- a/test/foundry/core/LiquidationManagerTest.t.sol
+++ b/test/foundry/core/LiquidationManagerTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.19;
 
 // test setup
-import {BorrowerOperationsTest, BabelMath, ITroveManager, SafeCast} from "./BorrowerOperationsTest.t.sol";
+import {BorrowerOperationsTest, BabelMath, ITroveManager, SafeCast, Math} from "./BorrowerOperationsTest.t.sol";
 import {BIMA_DECIMAL_PRECISION} from "../../../contracts/dependencies/Constants.sol";
 
 contract LiquidationManagerTest is BorrowerOperationsTest {
@@ -684,5 +684,84 @@ contract LiquidationManagerTest is BorrowerOperationsTest {
         user2CollateralGains = stabilityPool.getDepositorCollateralGain(users.user2);
         assertEq(user2CollateralGains.length, 1);
         assertEq(user2CollateralGains[0], 0);
+    }
+
+    // this test mainly exercises TroveManager::applyPendingRewards
+    // but is here as it requires liqudation to have happened
+    function test_troveManager_applyPendingRewards() external {
+        // set a positive interest rate
+        _setInterestRate(stakedBTCTroveMgr.MAX_INTEREST_RATE_IN_BPS());
+
+        // save owner trove coll & debt        
+        (uint256 ownerTroveCollPre, uint256 ownerTroveDebtPre)
+            = stakedBTCTroveMgr.getTroveCollAndDebt(users.owner);
+        assertEq(ownerTroveCollPre, 1000000000000000000);
+        assertEq(ownerTroveDebtPre, 1001000000000000000000);
+
+        // user1 opens a trove using 2 BTC collateral (price = $60,000 in MockOracle)
+        uint256 collateralAmount = 2e18;
+        uint256 debtAmountMax = _getMaxDebtAmount(collateralAmount);
+
+        _openTrove(users.user1, collateralAmount, debtAmountMax);
+
+        // set new value of btc to $50,000 to make trove liquidatable
+        uint256 elapsedTime = 1 weeks;
+        mockOracle.setResponse(mockOracle.roundId() + 1,
+                               int256(50000 * 10 ** 8),
+                               block.timestamp + elapsedTime,
+                               block.timestamp + elapsedTime,
+                               mockOracle.answeredInRound() + 1);
+        // warp time to prevent cached price being used and allow
+        // interest to build up
+        vm.warp(block.timestamp + elapsedTime);
+
+        // liquidate via `liquidate`
+        liquidationMgr.liquidate(stakedBTCTroveMgr, users.user1);
+
+        // verify correct trove status
+        assertEq(uint8(stakedBTCTroveMgr.getTroveStatus(users.user1)),
+                 uint8(ITroveManager.Status.closedByLiquidation));
+
+        assertEq(stakedBTCTroveMgr.L_collateral(), stakedBTCTroveMgr.defaultedCollateral());
+        assertEq(stakedBTCTroveMgr.L_debt(), stakedBTCTroveMgr.defaultedDebt());
+
+        // get pending collateral & debt rewards for owner trove
+        (uint256 pendingOwnerTroveCollReward,
+         uint256 pendingOwnerTroveDebtReward) = stakedBTCTroveMgr.getPendingCollAndDebtRewards(users.owner);
+
+        // save TroveManager pre state
+        TroveManagerState memory troveMgrStatePre = _getTroveManagerState();
+
+        /*
+        // calculate expected parameters
+        uint256 interestFactor = elapsedTime * stakedBTCTroveMgr.interestRate();
+        uint256 currentInterestIndex = statePre.activeInterestIndex +
+                                       Math.mulDiv(statePre.activeInterestIndex, interestFactor, TM_INTEREST_PRECISION);
+        uint256 newInterest = Math.mulDiv(statePre.totalActiveDebt, interestFactor, TM_INTEREST_PRECISION);
+        */
+
+        // trigger TroveManager::_applyPendingRewards for owner trove
+        vm.prank(address(borrowerOps));
+        (uint256 ownerTroveCollPost, uint256 ownerTroveDebtPost)
+            = stakedBTCTroveMgr.applyPendingRewards(users.owner);
+
+        // save TroveManager pre state
+        TroveManagerState memory troveMgrStatePost = _getTroveManagerState();
+
+        assertEq(ownerTroveCollPost, ownerTroveCollPre + pendingOwnerTroveCollReward);
+        // not quite right but very close
+        //assertEq(ownerTroveDebtPost, ownerTroveDebtPre + pendingOwnerTroveDebtReward + newInterest);
+        assertEq(ownerTroveDebtPost, 54376014465753424657527);
+
+        // verify owner trove reward snapshot correctly updated
+        (uint256 rsCollateral, uint256 rsDebt) = stakedBTCTroveMgr.rewardSnapshots(users.owner);
+        assertEq(rsCollateral, stakedBTCTroveMgr.L_collateral());
+        assertEq(rsDebt, stakedBTCTroveMgr.L_debt());
+
+        // verify pending rewards moved to active balances
+        assertEq(troveMgrStatePost.defaultedDebt, troveMgrStatePre.defaultedDebt - pendingOwnerTroveDebtReward);
+        assertEq(troveMgrStatePost.defaultedCollateral, troveMgrStatePre.defaultedCollateral - pendingOwnerTroveCollReward);
+        assertEq(troveMgrStatePost.totalActiveDebt, troveMgrStatePre.totalActiveDebt + pendingOwnerTroveDebtReward);
+        assertEq(troveMgrStatePost.totalActiveCollateral, troveMgrStatePre.totalActiveCollateral + pendingOwnerTroveCollReward);
     }
 }

--- a/test/foundry/core/StabilityPoolTest.t.sol
+++ b/test/foundry/core/StabilityPoolTest.t.sol
@@ -245,7 +245,7 @@ contract StabilityPoolTest is TestSetup {
 
     function test_claimReward_smallAmountOfStabilityPoolRewardsLost() external {
         // setup vault giving user1 half supply to lock for voting power
-        uint256 initialUnallocated = _vaultSetupAndLockTokens(INIT_BAB_TKN_TOTAL_SUPPLY/2);
+        uint256 initialUnallocated = _vaultSetupAndLockTokens(INIT_BAB_TKN_TOTAL_SUPPLY/2, true);
 
         // user votes for stability pool to get emissions
         IIncentiveVoting.Vote[] memory votes = new IIncentiveVoting.Vote[](1);

--- a/test/foundry/dao/AllocationVestingTest.t.sol
+++ b/test/foundry/dao/AllocationVestingTest.t.sol
@@ -12,6 +12,7 @@ contract AllocationVestingTest is TestSetup {
 
     uint256 internal constant totalAllocation = 100_000_000e18;
     uint256 internal constant maxTotalPreclaimPct = 10;
+    uint24  internal constant INIT_USER_POINTS = 50_000;
 
     function setUp() public virtual override {
         super.setUp();
@@ -35,15 +36,13 @@ contract AllocationVestingTest is TestSetup {
         AllocationVesting.AllocationSplit[] memory allocationSplits
             = new AllocationVesting.AllocationSplit[](2);
 
-        uint24 INIT_POINTS = 50000;
-
         // allocate to 2 users 50% 50%
         allocationSplits[0].recipient = users.user1;
-        allocationSplits[0].points = INIT_POINTS;
+        allocationSplits[0].points = INIT_USER_POINTS;
         allocationSplits[0].numberOfWeeks = 4;
 
         allocationSplits[1].recipient = users.user2;
-        allocationSplits[1].points = INIT_POINTS;
+        allocationSplits[1].points = INIT_USER_POINTS;
         allocationSplits[1].numberOfWeeks = 4;
 
         // setup allocations
@@ -56,22 +55,20 @@ contract AllocationVestingTest is TestSetup {
         // reverts on self-transfer exploit which would allow infinite point generation
         vm.expectRevert(AllocationVesting.SelfTransfer.selector);
         vm.prank(users.user1);
-        allocationVesting.transferPoints(users.user1, users.user1, INIT_POINTS);
+        allocationVesting.transferPoints(users.user1, users.user1, INIT_USER_POINTS);
     }
 
     function test_transferPoints_failBypassVestingViaPreclaim() external {
         AllocationVesting.AllocationSplit[] memory allocationSplits
             = new AllocationVesting.AllocationSplit[](2);
 
-        uint24 INIT_POINTS = 50000;
-
         // allocate to 2 users 50% 50%
         allocationSplits[0].recipient = users.user1;
-        allocationSplits[0].points = INIT_POINTS;
+        allocationSplits[0].points = INIT_USER_POINTS;
         allocationSplits[0].numberOfWeeks = 4;
 
         allocationSplits[1].recipient = users.user2;
-        allocationSplits[1].points = INIT_POINTS;
+        allocationSplits[1].points = INIT_USER_POINTS;
         allocationSplits[1].numberOfWeeks = 4;
 
         // setup allocations
@@ -88,9 +85,14 @@ contract AllocationVestingTest is TestSetup {
         // verify preclaimable amount before claiming
         assertEq(allocationVesting.preclaimable(users.user1), MAX_PRECLAIM);
 
+        // attempting to claim over MAX_PRECLAIM fails
+        vm.expectRevert(AllocationVesting.PreclaimTooLarge.selector);
+        vm.prank(users.user1);
+        allocationVesting.lockFutureClaims(users.user1, MAX_PRECLAIM + 1);
+
         // user1 does this once, passing 0 to preclaim max possible
         vm.prank(users.user1);
-        allocationVesting.lockFutureClaimsWithReceiver(users.user1, users.user1, 0);
+        allocationVesting.lockFutureClaims(users.user1, 0);
     
         // user1 has now preclaimed the max allowed
         (uint24 points, , , uint96 preclaimed) = allocationVesting.allocations(users.user1);
@@ -111,13 +113,13 @@ contract AllocationVestingTest is TestSetup {
         // user1 calls `transferPoints` to move their points to a new address
         address user1Second = address(0x1337);
         vm.prank(users.user1);
-        allocationVesting.transferPoints(users.user1, user1Second, INIT_POINTS);
+        allocationVesting.transferPoints(users.user1, user1Second, INIT_USER_POINTS);
 
         // but since `transferPoints` transfers preclaimed amounts, the
         // new address has its preclaimed amounts updated
         (points, , , preclaimed) = allocationVesting.allocations(user1Second);
         assertEq(preclaimed, MAX_PRECLAIM);
-        assertEq(points, INIT_POINTS);
+        assertEq(points, INIT_USER_POINTS);
 
         // old address has its preclaimed amounts reduced and also points
         (points, , , preclaimed) = allocationVesting.allocations(users.user1);
@@ -127,5 +129,95 @@ contract AllocationVestingTest is TestSetup {
         // both new and old address preclaimable amounts are 0
         assertEq(allocationVesting.preclaimable(users.user1), 0);
         assertEq(allocationVesting.preclaimable(user1Second), 0);
+    }
+
+    function test_transferPoints_failIncompatibleVestingPeriod() external {
+        AllocationVesting.AllocationSplit[] memory allocationSplits
+            = new AllocationVesting.AllocationSplit[](2);
+
+        // allocate to 2 users 50% 50%
+        allocationSplits[0].recipient = users.user1;
+        allocationSplits[0].points = INIT_USER_POINTS;
+        allocationSplits[0].numberOfWeeks = 4;
+
+        // user 2 gets different vesting weeks
+        allocationSplits[1].recipient = users.user2;
+        allocationSplits[1].points = INIT_USER_POINTS;
+        allocationSplits[1].numberOfWeeks = 5;
+
+        // setup allocations
+        uint256 vestingStart = block.timestamp + 1 weeks;
+        allocationVesting.setAllocations(allocationSplits, vestingStart);
+
+        // warp to start time
+        vm.warp(vestingStart + 1);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                AllocationVesting.IncompatibleVestingPeriod.selector,
+                allocationSplits[0].numberOfWeeks,
+                allocationSplits[1].numberOfWeeks));
+        vm.prank(users.user1);
+        allocationVesting.transferPoints(users.user1, users.user2, INIT_USER_POINTS);
+    }
+
+    function test_claim_failNothingToClaim() external {
+        vm.expectRevert(AllocationVesting.NothingToClaim.selector);
+        allocationVesting.claim(address(this));
+    }
+
+    function test_claim() public {
+        AllocationVesting.AllocationSplit[] memory allocationSplits
+            = new AllocationVesting.AllocationSplit[](2);
+
+        // allocate to 2 users 50% 50%
+        allocationSplits[0].recipient = users.user1;
+        allocationSplits[0].points = INIT_USER_POINTS;
+        allocationSplits[0].numberOfWeeks = 4;
+
+        allocationSplits[1].recipient = users.user2;
+        allocationSplits[1].points = INIT_USER_POINTS;
+        allocationSplits[1].numberOfWeeks = 4;
+
+        // setup allocations
+        uint256 vestingStart = block.timestamp + 1 weeks;
+        allocationVesting.setAllocations(allocationSplits, vestingStart);
+
+        // warp to end of vesting time
+        vm.warp(vestingStart + 4 weeks);
+
+        // verify unclaimed amounts
+        uint256 expectedClaimPerUser = totalAllocation / 2;
+
+        assertEq(allocationVesting.unclaimed(users.user1), expectedClaimPerUser);
+        assertEq(allocationVesting.unclaimed(users.user2), expectedClaimPerUser);
+        assertEq(allocationVesting.claimableNow(users.user1), expectedClaimPerUser);
+        assertEq(allocationVesting.claimableNow(users.user2), expectedClaimPerUser);
+
+        // claim
+        vm.prank(users.user1);
+        allocationVesting.claim(users.user1);
+
+        vm.prank(users.user2);
+        allocationVesting.claim(users.user2);
+
+        // verify end state
+        assertEq(babelToken.balanceOf(users.user1), expectedClaimPerUser);
+        assertEq(babelToken.balanceOf(users.user2), expectedClaimPerUser);
+        assertEq(allocationVesting.getClaimed(users.user1), expectedClaimPerUser);
+        assertEq(allocationVesting.getClaimed(users.user2), expectedClaimPerUser);
+
+        assertEq(allocationVesting.unclaimed(users.user1), 0);
+        assertEq(allocationVesting.unclaimed(users.user2), 0);
+        assertEq(allocationVesting.claimableNow(users.user1), 0);
+        assertEq(allocationVesting.claimableNow(users.user2), 0);
+    }
+
+    function test_claim_failAlreadyClaimed() external {
+        test_claim();
+
+        vm.expectRevert(AllocationVesting.NothingToClaim.selector);
+        vm.prank(users.user1);
+        allocationVesting.claim(users.user1);
     }
 }

--- a/test/foundry/dao/EmissionScheduleTest.t.sol
+++ b/test/foundry/dao/EmissionScheduleTest.t.sol
@@ -232,4 +232,36 @@ contract EmissionScheduleTest is TestSetup {
         assertEq(emissionSchedule.getWeeklyPctSchedule().length, 0);
     }
 
+    function test_setLockParameters_failNotOwner() external {
+        vm.expectRevert("Only owner");
+        emissionSchedule.setLockParameters(0, 0);
+    }
+
+    function test_setLockParameters_failExceedMaxLockWeeks() external {
+        uint64 lockWeeks = uint64(emissionSchedule.MAX_LOCK_WEEKS()) + 1;
+        
+        vm.expectRevert("Cannot exceed MAX_LOCK_WEEKS");
+        vm.prank(users.owner);
+        emissionSchedule.setLockParameters(lockWeeks, 0);
+    }
+
+    function test_setLockParameters_failZeroDecayWeeks() external {
+        uint64 lockWeeks = uint64(emissionSchedule.MAX_LOCK_WEEKS());
+        
+        vm.expectRevert("Decay weeks cannot be 0");
+        vm.prank(users.owner);
+        emissionSchedule.setLockParameters(lockWeeks, 0);
+    }
+
+    function test_setLockParameters(uint64 lockWeeks, uint64 decayWeeks) external {
+        lockWeeks  = uint64(bound(lockWeeks, 0, emissionSchedule.MAX_LOCK_WEEKS()));
+        decayWeeks = uint64(bound(decayWeeks, 1, type(uint64).max));
+
+        vm.prank(users.owner);
+        assertTrue(emissionSchedule.setLockParameters(lockWeeks, decayWeeks));
+
+        assertEq(emissionSchedule.lockWeeks(), lockWeeks);
+        assertEq(emissionSchedule.lockDecayWeeks(), decayWeeks);
+    }
+
 }

--- a/test/foundry/dao/InterimAdminTest.t.sol
+++ b/test/foundry/dao/InterimAdminTest.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {IBabelCore} from "../../../contracts/interfaces/IBabelCore.sol";
+import {BIMA_100_PCT} from "../../../contracts/dependencies/Constants.sol";
+
+// test setup
+import {TestSetup, InterimAdmin, IBabelVault} from "../TestSetup.sol";
+
+contract InterimAdminTest is TestSetup {
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        assertEq(interimAdmin.adminVoting(), address(0));
+        assertEq(interimAdmin.getProposalCount(), 0);
+    }
+
+    // helper function to verify proposal data after creation
+    function _verifyCreatedProposal(uint256 proposalId, 
+                                    InterimAdmin.Action[] memory payload) internal view {
+        assertEq(interimAdmin.getProposalCreatedAt(proposalId), block.timestamp);
+        assertEq(interimAdmin.getProposalCanExecuteAfter(proposalId),
+                 block.timestamp + interimAdmin.MIN_TIME_TO_EXECUTION());
+        assertFalse(interimAdmin.getProposalExecuted(proposalId));
+        assertFalse(interimAdmin.getProposalCanExecute(proposalId));
+
+        InterimAdmin.Action[] memory savedPayload = interimAdmin.getProposalPayload(proposalId);
+        assertEq(payload.length, savedPayload.length);
+        for(uint256 i; i<payload.length; i++) {
+            assertEq(payload[i].target, savedPayload[i].target);
+            assertEq(payload[i].data, savedPayload[i].data);
+        }
+
+        // also test view function InterminAdmin::getProposalData
+        (
+            uint256 createdAt,
+            uint256 canExecuteAfter,
+            bool executed,
+            bool canExecute,
+            InterimAdmin.Action[] memory savedPayload2
+        ) = interimAdmin.getProposalData(proposalId);
+
+        assertEq(createdAt, block.timestamp);
+        assertEq(canExecuteAfter, block.timestamp + interimAdmin.MIN_TIME_TO_EXECUTION());
+        assertEq(executed, false);
+        assertEq(canExecute, false);
+
+        assertEq(payload.length, savedPayload2.length);
+        for(uint256 i; i<payload.length; i++) {
+            assertEq(payload[i].target, savedPayload2[i].target);
+            assertEq(payload[i].data, savedPayload2[i].data);
+        }
+    }
+
+    function test_setAdminVoting_failNotOwner() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+        interimAdmin.setAdminVoting(address(0));
+    }
+
+    function test_setAdminVoting_failNotContract() external {
+        vm.expectRevert("adminVoting must be a contract");
+        vm.prank(users.owner);
+        interimAdmin.setAdminVoting(users.user1);
+    }
+
+    function test_setAdminVoting() public {
+        vm.prank(users.owner);
+        interimAdmin.setAdminVoting(address(babelVault));
+
+        assertEq(interimAdmin.adminVoting(), address(babelVault));
+    }
+
+    function test_setAdminVoting_failAlreadySet() external {
+        test_setAdminVoting();
+
+        vm.expectRevert("Already set");
+        vm.prank(users.owner);
+        interimAdmin.setAdminVoting(address(babelCore));
+    }
+
+    function test_createNewProposal_failNotOwner() external {
+        InterimAdmin.Action[] memory payload;
+
+        vm.expectRevert("Ownable: caller is not the owner");
+        interimAdmin.createNewProposal(payload);
+    }
+
+    function test_createNewProposal_failEmpty() external {
+        InterimAdmin.Action[] memory payload;
+
+        vm.expectRevert("Empty payload");
+        vm.prank(users.owner);
+        interimAdmin.createNewProposal(payload);
+    }
+
+    function test_createNewProposal_failSetGuardian() external {
+        InterimAdmin.Action[] memory payload = new InterimAdmin.Action[](1);
+        payload[0].target = address(babelCore);
+        payload[0].data   = abi.encodeWithSelector(IBabelCore.setGuardian.selector, users.user1);
+
+        vm.expectRevert("Cannot change guardian");
+        vm.prank(users.owner);
+        interimAdmin.createNewProposal(payload);
+    }
+
+    function test_createNewProposal() public returns(uint256 proposalId) {
+        InterimAdmin.Action[] memory payload = new InterimAdmin.Action[](1);
+        payload[0].target = address(babelVault);
+        payload[0].data   = abi.encodeWithSelector(IBabelVault.unallocatedTotal.selector);
+
+        vm.prank(users.owner);
+        proposalId = interimAdmin.createNewProposal(payload);
+
+        _verifyCreatedProposal(proposalId, payload);
+    }
+
+    function test_createNewProposal_failMaxDailyProposals() public {
+        for(uint256 i; i<interimAdmin.MAX_DAILY_PROPOSALS(); i++) {
+            test_createNewProposal();
+        }
+
+        InterimAdmin.Action[] memory payload = new InterimAdmin.Action[](1);
+        payload[0].target = address(babelCore);
+        payload[0].data   = abi.encodeWithSelector(IBabelVault.unallocatedTotal.selector);
+
+        vm.expectRevert("MAX_DAILY_PROPOSALS");
+        vm.prank(users.owner);
+        interimAdmin.createNewProposal(payload);
+    }
+
+    function test_createNewProposal_maxDailyResetOnNewDay() external {
+        test_createNewProposal_failMaxDailyProposals();
+        vm.warp(block.timestamp + 1 days);
+        test_createNewProposal_failMaxDailyProposals();
+    }
+
+    function test_cancelProposal_failNormalUser() external {
+        uint256 proposalId = test_createNewProposal();
+        vm.expectRevert("Unauthorized");
+        interimAdmin.cancelProposal(proposalId);
+    }
+
+    function test_cancelProposal_failInvalidId() external {
+        uint256 proposalId = test_createNewProposal();
+        vm.expectRevert("Invalid ID");
+        vm.prank(users.owner);
+        interimAdmin.cancelProposal(proposalId + 1);
+    }
+
+    function test_cancelProposal() public returns(uint256 cancelledProposalId) {
+        cancelledProposalId = test_createNewProposal();
+        vm.prank(users.owner);
+        interimAdmin.cancelProposal(cancelledProposalId);
+        assertTrue(interimAdmin.getProposalExecuted(cancelledProposalId));
+        assertFalse(interimAdmin.getProposalCanExecute(cancelledProposalId));
+
+        cancelledProposalId = test_createNewProposal();
+        vm.prank(users.guardian);
+        interimAdmin.cancelProposal(cancelledProposalId);
+        assertTrue(interimAdmin.getProposalExecuted(cancelledProposalId));
+        assertFalse(interimAdmin.getProposalCanExecute(cancelledProposalId));
+    }
+
+    function test_cancelProposal_failAlreadyCancelled() external {
+        uint256 cancelledProposalId = test_cancelProposal();
+
+        vm.expectRevert("Already processed");
+        vm.prank(users.owner);
+        interimAdmin.cancelProposal(cancelledProposalId);
+    }
+
+    function test_cancelProposal_failAlreadyExecuted() external {
+        uint256 executedProposalId = test_executeProposal();
+
+        vm.expectRevert("Already processed");
+        vm.prank(users.owner);
+        interimAdmin.cancelProposal(executedProposalId);
+    }
+
+    function test_executeProposal_failNotOwner() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+        interimAdmin.executeProposal(0);
+    }
+
+    function test_executeProposal_failInvalidId() external {
+        uint256 proposalId = test_createNewProposal();
+        vm.expectRevert("Invalid ID");
+        vm.prank(users.owner);
+        interimAdmin.executeProposal(proposalId + 1);
+    }
+
+    function test_executeProposal_failAlreadyCancelled() external {
+        uint256 cancelledProposalId = test_cancelProposal();
+
+        vm.expectRevert("Already processed");
+        vm.prank(users.owner);
+        interimAdmin.executeProposal(cancelledProposalId);
+    }
+
+    function test_executeProposal_failMinTimeNotElapsed() external {
+        uint256 proposalId = test_createNewProposal();
+        vm.expectRevert("MIN_TIME_TO_EXECUTION");
+        vm.prank(users.owner);
+        interimAdmin.executeProposal(proposalId);
+    }
+
+    function test_executeProposal_failMaxTimeElapsed() external {
+        uint256 proposalId = test_createNewProposal();
+
+        vm.warp(interimAdmin.getProposalCanExecuteAfter(proposalId) +
+                interimAdmin.MAX_TIME_TO_EXECUTION() + 1);
+
+        vm.expectRevert("MAX_TIME_TO_EXECUTION");
+        vm.prank(users.owner);
+        interimAdmin.executeProposal(proposalId);
+    }
+
+    function test_executeProposal() public returns(uint256 executedProposalId) {
+        executedProposalId = test_createNewProposal();
+
+        vm.warp(interimAdmin.getProposalCanExecuteAfter(executedProposalId) + 1);
+        vm.prank(users.owner);
+        interimAdmin.executeProposal(executedProposalId);
+
+        assertTrue(interimAdmin.getProposalExecuted(executedProposalId));
+        assertFalse(interimAdmin.getProposalCanExecute(executedProposalId));
+    }
+
+    function test_executeProposal_failAlreadyExecuted() external {
+        uint256 executedProposalId = test_executeProposal();
+
+        vm.expectRevert("Already processed");
+        vm.prank(users.owner);
+        interimAdmin.executeProposal(executedProposalId);
+    }
+
+    function test_acceptTransferOwnership_failNotOwner() external {
+        vm.expectRevert("Ownable: caller is not the owner");
+        interimAdmin.acceptTransferOwnership();
+    }
+
+    function test_acceptTransferOwnership() public {
+        vm.prank(users.owner);
+        babelCore.commitTransferOwnership(address(interimAdmin));
+
+        vm.warp(babelCore.ownershipTransferDeadline());
+
+        vm.prank(users.owner);
+        interimAdmin.acceptTransferOwnership();
+
+        assertEq(babelCore.owner(), address(interimAdmin));
+    }
+
+    function test_transferOwnershipToAdminVoting_failNormalUser() external {
+        vm.expectRevert("Unauthorized");
+        interimAdmin.transferOwnershipToAdminVoting();
+    }
+
+    function test_transferOwnershipToAdminVoting() external {
+        vm.prank(users.owner);
+        interimAdmin.setAdminVoting(address(babelVault));
+        assertEq(interimAdmin.adminVoting(), address(babelVault));
+
+        test_acceptTransferOwnership();
+
+        vm.prank(users.owner);
+        interimAdmin.transferOwnershipToAdminVoting();
+        assertEq(babelCore.pendingOwner(), address(babelVault));
+        assertEq(babelCore.ownershipTransferDeadline(),
+                 block.timestamp + babelCore.OWNERSHIP_TRANSFER_DELAY());
+
+        vm.prank(address(interimAdmin));
+        babelCore.revokeTransferOwnership();
+        assertEq(babelCore.pendingOwner(), address(0));
+        assertEq(babelCore.ownershipTransferDeadline(), 0);
+
+        vm.prank(users.guardian);
+        interimAdmin.transferOwnershipToAdminVoting();
+        assertEq(babelCore.pendingOwner(), address(babelVault));
+        assertEq(babelCore.ownershipTransferDeadline(),
+                 block.timestamp + babelCore.OWNERSHIP_TRANSFER_DELAY());
+    }
+}

--- a/test/foundry/dao/TokenLockerTest.t.sol
+++ b/test/foundry/dao/TokenLockerTest.t.sol
@@ -525,6 +525,10 @@ contract TokenLockerTest is TestSetup {
         // save previous decay rate
         uint256 totalDecayRatePre = tokenLocker.totalDecayRate();
 
+        // get expected amounts using TokenLocker::getWithdrawWithPenaltyAmounts
+        (uint256 expectedAmountWithdrawn, uint256 expectedPenaltyAmountPaid)
+            = tokenLocker.getWithdrawWithPenaltyAmounts(users.user1, type(uint256).max);
+
         // perform the withdraw with penalty
         vm.prank(users.user1);
         tokenLocker.withdrawWithPenalty(type(uint256).max);
@@ -546,6 +550,10 @@ contract TokenLockerTest is TestSetup {
 
         // verify token decay rate reduced by withdrawn amount
         assertEq(tokenLocker.totalDecayRate(), totalDecayRatePre - lockedAmount);
+
+        // verify TokenLocker::getWithdrawWithPenaltyAmounts returned correct values
+        assertEq(penaltyOnAmount, expectedPenaltyAmountPaid);
+        assertEq(expectedAmountWithdrawn, lockedAmount * INIT_LOCK_TO_TOKEN_RATIO - penaltyOnAmount);
     }
 
     function test_withdrawWithPenalty_fixActiveLockWithZeroLocked() external {

--- a/test/foundry/dao/VaultTest.t.sol
+++ b/test/foundry/dao/VaultTest.t.sol
@@ -217,7 +217,7 @@ contract VaultTest is TestSetup {
 
         // tokens were effectively lost since the vault's unallocated supply decreased
         // but no tokens were actually allocated to receivers since there was no
-        // voting weight
+        // voting weight in the first week
     }
 
     function test_transferAllocatedTokens_noPendingRewards_inBoostGraceWeeks_inVaultLockWeeks(uint256 transferAmount) external {
@@ -854,7 +854,11 @@ contract VaultTest is TestSetup {
 
         // cache state prior to allocateNewEmissions
         uint16 systemWeek = SafeCast.toUint16(babelVault.getWeek());
-        
+
+        // one receiver as all the voting weight
+        assertEq(incentiveVoting.getReceiverWeight(RECEIVER_ID), incentiveVoting.getTotalWeight());
+        assertEq(incentiveVoting.getReceiverVotePct(RECEIVER_ID, systemWeek + 1), 1e18);
+
         // initial unallocated supply has not changed
         assertEq(babelVault.unallocatedTotal(), initialUnallocated);
 
@@ -892,6 +896,52 @@ contract VaultTest is TestSetup {
         // doesn't return any more since already been called for current system week
         assertEq(allocated2, 0);
         assertEq(babelVault.allocated(receiver), firstWeekEmissions);
+
+        // re-register account weight
+        vm.prank(users.user1);
+        incentiveVoting.registerAccountWeight(users.user1, 51);
+
+        // verify votes preserved
+        IIncentiveVoting.Vote[] memory votes2 = incentiveVoting.getAccountCurrentVotes(users.user1);
+        assertEq(votes2.length, votes.length);
+        assertEq(votes2[0].id, votes[0].id);
+        assertEq(votes2[0].points, votes[0].points);
+
+        // change vote weight
+        votes[0].points /= 2;
+        vm.prank(users.user1);
+
+        // register weight and vote again
+        incentiveVoting.registerAccountWeightAndVote(users.user1, 51, votes);
+
+        // verify previous vote cleared and new vote saved
+        votes2 = incentiveVoting.getAccountCurrentVotes(users.user1);
+        assertEq(votes2.length, votes.length);
+        assertEq(votes2[0].id, votes[0].id);
+        assertEq(votes2[0].points, votes[0].points);
+
+        // change vote weight back to original
+        votes[0].points = incentiveVoting.MAX_POINTS();
+
+        // vote with clear previous to delete old vote
+        vm.prank(users.user1);
+        incentiveVoting.vote(users.user1, votes, true);
+
+        // verify new vote
+        votes2 = incentiveVoting.getAccountCurrentVotes(users.user1);
+        assertEq(votes2.length, votes.length);
+        assertEq(votes2[0].id, votes[0].id);
+        assertEq(votes2[0].points, votes[0].points);
+    }
+
+    function test_clearRegisteredWeight() external {
+        test_allocateNewEmissions_oneReceiverWithVotingWeight();
+
+        vm.prank(users.user1);
+        incentiveVoting.clearRegisteredWeight(users.user1);
+
+        IIncentiveVoting.Vote[] memory votes = incentiveVoting.getAccountCurrentVotes(users.user1);
+        assertEq(votes.length, 0);
     }
 
     function test_allocateNewEmissions_oneDisabledReceiverWithVotingWeight() external {
@@ -1144,11 +1194,18 @@ contract VaultTest is TestSetup {
         vm.prank(users.user1);
         incentiveVoting.registerAccountWeightAndVote(users.user1, 52, votes);
 
+        (uint256 frozenWeight, ITokenLocker.LockData[] memory lockData)
+            = incentiveVoting.getAccountRegisteredLocks(users.user1);
+        assertEq(frozenWeight, 0);
+        assertEq(lockData.length, activeLockData.length);
+        assertEq(activeLockData[0].amount, lockData[0].amount);
+        assertEq(activeLockData[0].weeksToUnlock, lockData[0].weeksToUnlock);
+
         // verify user1 has 1 active vote using their unfrozen locked weight
         votes = incentiveVoting.getAccountCurrentVotes(users.user1);
         assertEq(votes.length, 1);
         assertEq(votes[0].id, RECEIVER_ID);
-        assertEq(votes[0].points, 10_000);
+        assertEq(votes[0].points, incentiveVoting.MAX_POINTS());
 
         // user1 freezes their lock
         vm.prank(users.user1);
@@ -1164,6 +1221,83 @@ contract VaultTest is TestSetup {
         tokenLocker.unfreeze(false); // keepIncentivesVote = false
 
         // user1 had their active vote cleared
+        votes = incentiveVoting.getAccountCurrentVotes(users.user1);
+        assertEq(votes.length, 0);
+    }
+
+    function test_freeze_vote_unfreeze(bool keepIncentivesVote) external {
+        // setup vault giving user1 half supply to lock for voting power
+        _vaultSetupAndLockTokens(INIT_BAB_TKN_TOTAL_SUPPLY/2, true);
+
+        // user1 freezes their lock
+        vm.prank(users.user1);
+        tokenLocker.freeze();
+
+        // register receiver
+        uint256 RECEIVER_ID = _vaultRegisterReceiver(address(mockEmissionReceiver), 1);
+
+        // user1 votes for receiver using their frozen locked weight
+        IIncentiveVoting.Vote[] memory votes = new IIncentiveVoting.Vote[](1);
+        votes[0].id = RECEIVER_ID;
+        votes[0].points = incentiveVoting.MAX_POINTS();
+        
+        vm.prank(users.user1);
+        incentiveVoting.registerAccountWeightAndVote(users.user1, 52, votes);
+
+        // verify user1 has 1 frozen lock
+        (ITokenLocker.LockData[] memory activeLockData, uint256 frozenAmount)
+            = tokenLocker.getAccountActiveLocks(users.user1, 0);
+        assertEq(activeLockData.length, 0); // 0 active lock
+        assertGt(frozenAmount, 0); // positive frozen amount
+
+        // user1 unfreezes
+        vm.prank(users.user1);
+        tokenLocker.unfreeze(keepIncentivesVote);
+
+        // refresh votes after unfreeze
+        votes = incentiveVoting.getAccountCurrentVotes(users.user1);
+
+        if(keepIncentivesVote) {
+            assertEq(votes.length, 1);
+            assertEq(votes[0].id, RECEIVER_ID);
+            assertEq(votes[0].points, incentiveVoting.MAX_POINTS());
+        }
+        else {
+            assertEq(votes.length, 0);
+        }
+    }
+
+
+    function test_freeze_vote_removeVotes() external {
+        // setup vault giving user1 half supply to lock for voting power
+        _vaultSetupAndLockTokens(INIT_BAB_TKN_TOTAL_SUPPLY/2, true);
+
+        // user1 freezes their lock
+        vm.prank(users.user1);
+        tokenLocker.freeze();
+
+        // register receiver
+        uint256 RECEIVER_ID = _vaultRegisterReceiver(address(mockEmissionReceiver), 1);
+
+        // user1 votes for receiver using their frozen locked weight
+        IIncentiveVoting.Vote[] memory votes = new IIncentiveVoting.Vote[](1);
+        votes[0].id = RECEIVER_ID;
+        votes[0].points = incentiveVoting.MAX_POINTS();
+        
+        vm.prank(users.user1);
+        incentiveVoting.registerAccountWeightAndVote(users.user1, 52, votes);
+
+        // verify user1 has 1 frozen lock
+        (ITokenLocker.LockData[] memory activeLockData, uint256 frozenAmount)
+            = tokenLocker.getAccountActiveLocks(users.user1, 0);
+        assertEq(activeLockData.length, 0); // 0 active lock
+        assertGt(frozenAmount, 0); // positive frozen amount
+
+        // user1 clears their votes while still frozen
+        vm.prank(users.user1);
+        incentiveVoting.clearVote(users.user1);
+
+        // refresh votes after clear
         votes = incentiveVoting.getAccountCurrentVotes(users.user1);
         assertEq(votes.length, 0);
     }


### PR DESCRIPTION
Lots of additional test coverage resulting in:
* 92.6% for `core` (excluding `helpers`)
* 89.6% for `dao`
* 91.1% for `dependencies`

Fixed a couple of minor bugs in a pair of view functions as well.