### PR TITLE
PFE-1: Delayed oracle price updates

### DIFF
--- a/contracts/core/StorkOracleWrapper.sol
+++ b/contracts/core/StorkOracleWrapper.sol
@@ -59,7 +59,7 @@ contract StorkOracleWrapper is IAggregatorV3Interface {
     (uint64 timestampNs, int192 quantizedValue) = storkOracle.getTemporalNumericValueV1(encodedAssetId);
 
     answer = int256(quantizedValue);
-    updatedAt = timestampNs / 1e9 - 1 minutes;
+    updatedAt = timestampNs / 1e9 - 1 seconds;
     startedAt = updatedAt;
     roundId = _roundId;
     answeredInRound = _roundId;
@@ -75,7 +75,7 @@ contract StorkOracleWrapper is IAggregatorV3Interface {
     answer = int256(quantizedValue);
     updatedAt = timestampNs / 1e9;
     startedAt = updatedAt;
-    roundId = uint80(updatedAt / 1 minutes); // increment round every 1 minute
+    roundId = uint80(updatedAt / 1 seconds); // increment round every second
     answeredInRound = roundId;
   }
 }

--- a/test/foundry/StorkOracleWrapper.t.sol
+++ b/test/foundry/StorkOracleWrapper.t.sol
@@ -41,7 +41,7 @@ contract StorkOracleWrapperTest is Test {
 
     (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, ) = storkOracleWrapper.latestRoundData();
 
-    assertEq(roundId, timestampNs / 1e9 / 1 minutes);
+    assertEq(roundId, timestampNs / 1e9 / 1 seconds);
     assertEq(answer, quantizedValue);
     assertEq(startedAt, timestampNs / 1e9);
     assertEq(updatedAt, timestampNs / 1e9);
@@ -54,8 +54,8 @@ contract StorkOracleWrapperTest is Test {
 
     assertEq(roundId, _roundId);
     assertEq(answer, quantizedValue);
-    assertEq(startedAt, timestampNs / 1e9 - 1 minutes);
-    assertEq(updatedAt, timestampNs / 1e9 - 1 minutes);
+    assertEq(startedAt, timestampNs / 1e9 - 1 seconds);
+    assertEq(updatedAt, timestampNs / 1e9 - 1 seconds);
   }
 
   function testFlow() public {

--- a/test/foundry/StorkOracleWrapper.t.sol
+++ b/test/foundry/StorkOracleWrapper.t.sol
@@ -20,7 +20,7 @@ contract StorkOracleWrapperTest is Test {
   string HOLESKY_RPC_URL = vm.envString("HOLESKY_RPC_URL");
 
   function setUp() public {
-    vm.createSelectFork(HOLESKY_RPC_URL, 	2184438);
+    vm.createSelectFork(HOLESKY_RPC_URL);
 
     storkOracle = IStorkOracle(0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62);
     encodedAssetId = bytes32(0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de);
@@ -66,29 +66,17 @@ contract StorkOracleWrapperTest is Test {
     address borrowOperationsAddress = 0x98cb20D30da0389028EB71eF299B688979F5cB8b;
     address priceFeedAddress = 0xEdd95b1325140Eb6c06d8C738DE98accb2104dFB;
 
-    (/*uint80 roundId1*/, int256 answer, , /*uint256 updatedAt*/, ) = IAggregatorV3Interface(oracleAddress).latestRoundData();
-    // console.log("ROUND ID AND ANSWER AND UPDATED AT FROM ORACLE: ");
-    // console.log(roundId1);
-    console.log(answer);
-    // console.log(updatedAt);
-
-    console.log("FETCHING PRICE");
+    IAggregatorV3Interface(oracleAddress).latestRoundData();
 
     PriceFeed(priceFeedAddress).fetchPrice(collateralAddress);
 
-    console.log("PRICE FETCHED");
-
-    console.log("APPROVING COLLATERAL");
-
-    vm.prank(0x39d2770AbcC456f6C6be820705eD966592E0ad96); // This address holds the mock collateral token
     IERC20(collateralAddress).approve(borrowOperationsAddress, 1e18);
 
-    console.log("OPENING TROVE");
+    deal(collateralAddress, address(this), 1e18, true);
 
-    vm.prank(0x39d2770AbcC456f6C6be820705eD966592E0ad96);
     IBorrowerOperations(borrowOperationsAddress).openTrove(
       ITroveManager(troveManagerAddress),
-      0x39d2770AbcC456f6C6be820705eD966592E0ad96,
+      address(this),
       0.1e18,
       1e18,
       10_000e18,
@@ -96,7 +84,7 @@ contract StorkOracleWrapperTest is Test {
       address(0)
     );
 
-    console.log(IERC20(collateralAddress).balanceOf(0x39d2770AbcC456f6C6be820705eD966592E0ad96));
-    console.log(ITroveManager(troveManagerAddress).debtToken().balanceOf(0x39d2770AbcC456f6C6be820705eD966592E0ad96));
+    console.log(IERC20(collateralAddress).balanceOf(address(this)));
+    console.log(ITroveManager(troveManagerAddress).debtToken().balanceOf(address(this)));
   }
 }

--- a/test/foundry/StorkOracleWrapperMocked.t.sol
+++ b/test/foundry/StorkOracleWrapperMocked.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {TestSetup} from "./TestSetup.sol";
+
+import {StorkOracleWrapper, IStorkOracle} from "../../contracts/core/StorkOracleWrapper.sol";
+import {MockERC20} from "forge-std/mocks/MockERC20.sol";
+
+import {console} from "forge-std/console.sol";
+
+contract MockStorkOracle {
+  uint64 public timestampNs;
+  int192 public quantizedValue;
+
+  function getTemporalNumericValueV1(bytes32) external view returns (uint64, int192) {
+    return (timestampNs, quantizedValue);
+  }
+
+  function setPrice(int192 _quantizedValue) public {
+    timestampNs = uint64(block.timestamp * 1e9);
+    quantizedValue = _quantizedValue;
+  }
+}
+
+contract StorkOracleWrapperMockedTest is TestSetup {
+  MockStorkOracle public storkOracle;
+  StorkOracleWrapper public storkOracleWrapper;
+
+  bytes32 public encodedAssetId;
+
+  function testInitialState() public {
+    _setUp();
+
+    assertEq(address(storkOracleWrapper.storkOracle()), address(storkOracle));
+    assertEq(storkOracleWrapper.encodedAssetId(), bytes32(0));
+    assertEq(storkOracleWrapper.decimals(), storkOracleWrapper.DECIMAL_PRECISION());
+    assertEq(storkOracleWrapper.description(), "AggregatorV3Interface Wrapper for Stork Oracle");
+    assertEq(storkOracleWrapper.version(), 1);
+  }
+
+  function test_latestRoundData(int192 price, uint32 blockTimestamp) public {
+    vm.warp(blockTimestamp);
+
+    _setUp();
+
+    storkOracle.setPrice(price);
+
+    (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, ) = storkOracleWrapper.latestRoundData();
+
+    assertEq(block.timestamp, blockTimestamp);
+
+    assertEq(roundId, block.timestamp / 1 seconds);
+    assertEq(answer, price);
+    assertEq(startedAt, block.timestamp);
+    assertEq(updatedAt, block.timestamp);
+  }
+
+  function test_roundData(int192 price, uint32 blockTimestamp, uint80 _roundId) public {
+    vm.assume(blockTimestamp > 100);
+
+    vm.warp(blockTimestamp);
+
+    _setUp();
+
+    storkOracle.setPrice(price);
+
+    (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, ) = storkOracleWrapper.getRoundData(_roundId);
+
+    assertEq(block.timestamp, blockTimestamp);
+
+    assertEq(roundId, _roundId);
+    assertEq(answer, price);
+    assertEq(startedAt, block.timestamp - 1 seconds);
+    assertEq(updatedAt, block.timestamp - 1 seconds);
+  }
+
+  // Test how the PriceFeed contract will handle the price change, if the new price has been set under a minute
+  function test_PriceChangeUnderMinute() public {
+    _setUp();
+
+    vm.startPrank(users.owner);
+
+    MockERC20 collateral = new MockERC20();
+
+    storkOracle.setPrice(60_000e18);
+
+    priceFeed.setOracle(address(collateral), address(storkOracleWrapper), 80000, bytes4(0x00000000), 18, false);
+
+    assertEq(priceFeed.fetchPrice(address(collateral)), 60_000e18);
+
+    skip(1.1 minutes);
+
+    storkOracle.setPrice(70_000e18);
+
+    assertEq(priceFeed.fetchPrice(address(collateral)), 70_000e18);
+
+    skip(0.1 minutes);
+
+    storkOracle.setPrice(10_000e18);
+
+    assertEq(priceFeed.fetchPrice(address(collateral)), 10_000e18);
+  }
+
+  function _setUp() internal {
+    storkOracle = new MockStorkOracle();
+
+    storkOracleWrapper = new StorkOracleWrapper(address(storkOracle), bytes32(0));
+  }
+}


### PR DESCRIPTION
- Update the `roundId` handling for `StorkOracleWrapper` contract, to avoid delayed price updates in case of price update in less then a minute.
- Add additional tests for validating this fix.