### PR TITLE
TMA-1 Innacurate  Base Rate Decay Due to Time Rounding

### DIFF
--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -632,7 +632,9 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         uint256 timePassed = block.timestamp - lastFeeOperationTime;
 
         if (timePassed >= SECONDS_IN_ONE_MINUTE) {
-            lastFeeOperationTime = block.timestamp;
+            uint256 minutesPassed = timePassed / SECONDS_IN_ONE_MINUTE;
+            
+            lastFeeOperationTime += minutesPassed * SECONDS_IN_ONE_MINUTE;
             emit LastFeeOpTimeUpdated(block.timestamp);
         }
     }


### PR DESCRIPTION
- Fix the calculation of `lastFeeOperationTime` to ensure correct base rate decay calculation