### PR TITLE
#239 fix flawed RewardIntegral update logic of TroveManager

### DIFF
--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -1277,7 +1277,9 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
             if (prevDebt != debt) {
                 t.debt = debt;
             }
-            _updateIntegrals(_borrower, prevDebt, supply);
+            _updateIntegrals(_borrower, debt, supply);
+            //
+      
         }
     }
 

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -1278,8 +1278,6 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
                 t.debt = debt;
             }
             _updateIntegrals(_borrower, debt, supply);
-            //
-      
         }
     }
 


### PR DESCRIPTION
Corrected _updateIntegrals to pass the updated debt (after interest) instead of the previous debt.
![Screenshot 2025-01-21 102610](https://github.com/user-attachments/assets/326f2713-c56c-41c5-aec8-5beeeda2162f)
![Screenshot 2025-01-21 102845](https://github.com/user-attachments/assets/98916c4f-dd84-49c3-a9aa-1b5ce7fe68e1)
