### PR TITLE
#137 Fix the rounding error causing loss of mint rewards in TroveManager

### DIFF
--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -135,7 +135,7 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
     uint256[65535] public dailyMintReward;
 
     // week -> day -> total amount redeemed this day
-    uint32[7][65535] private totalMints;
+    uint256[7][65535] private totalMints;
 
     // Array of all active trove addresses - used to compute
     // an approximate hint off-chain, for the sorted list insertion
@@ -156,7 +156,7 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
     mapping(address borrower => RewardSnapshot) public rewardSnapshots;
 
     struct VolumeData {
-        uint32 amount;
+        uint256 amount;
         uint32 week;
         uint32 day;
     }
@@ -412,7 +412,7 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
         day = (duration % 1 weeks) / 1 days;
     }
 
-    function getTotalMints(uint256 week) external view returns (uint32[7] memory mints) {
+    function getTotalMints(uint256 week) external view returns (uint256[7] memory mints) {
         mints = totalMints[week];
     }
 
@@ -1000,7 +1000,7 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
         amount = vault.allocateNewEmissions(id.minting);
         uint256 reward = dailyMintReward[previousWeek];
         if (reward > 0) {
-            uint32[7] memory totals = totalMints[previousWeek];
+            uint256[7] memory totals = totalMints[previousWeek];
             for (uint256 i; i < 7; i++) {
                 if (totals[i] == 0) {
                     amount += reward;
@@ -1200,7 +1200,7 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
     }
 
     function _updateMintVolume(address account, uint256 initialAmount) internal {
-        uint32 amount = SafeCast.toUint32(initialAmount / VOLUME_MULTIPLIER);
+        uint256 amount = initialAmount;
         (uint256 week, uint256 day) = getWeekAndDay();
         totalMints[week][day] += amount;
 

--- a/contracts/core/TroveManager.sol
+++ b/contracts/core/TroveManager.sol
@@ -38,9 +38,6 @@ contract TroveManager is ITroveManager, BimaBase, BimaOwnable, SystemStart {
     uint256 constant INTEREST_PRECISION = 1e27;
     uint256 constant SECONDS_IN_YEAR = 365 days;
 
-    // volume-based amounts are divided by this value to allow storing as uint32
-    uint256 constant VOLUME_MULTIPLIER = 1e20;
-
     // Maximum interest rate must be lower than the minimum LST staking yield
     // so that over time the actual TCR becomes greater than the calculated TCR
     uint256 public constant MAX_INTEREST_RATE_IN_BPS = 400; // 4%

--- a/contracts/interfaces/ITroveManager.sol
+++ b/contracts/interfaces/ITroveManager.sol
@@ -180,7 +180,7 @@ interface ITroveManager is IBimaBase, IBimaOwnable, ISystemStart, IEmissionRecei
             uint256 activeInterestIndex
         );
 
-    function accountLatestMint(address) external view returns (uint32 amount, uint32 week, uint32 day);
+    function accountLatestMint(address) external view returns (uint256 amount, uint32 week, uint32 day);
 
     function activeInterestIndex() external view returns (uint256);
 
@@ -236,7 +236,7 @@ interface ITroveManager is IBimaBase, IBimaOwnable, ISystemStart, IEmissionRecei
 
     function getTotalActiveDebt() external view returns (uint256);
 
-    function getTotalMints(uint256 week) external view returns (uint32[7] memory);
+    function getTotalMints(uint256 week) external view returns (uint256[7] memory);
 
     function getTroveCollAndDebt(address _borrower) external view returns (uint256 coll, uint256 debt);
 

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -57,8 +57,8 @@ contract BorrowerOperationsTest is StabilityPoolTest {
         assertEq(stakedBTCTroveMgr.getTroveStake(users.owner), OWNER_TROVE_COLLATERAL);
 
         (uint256 week, uint256 day) = stakedBTCTroveMgr.getWeekAndDay();
-        uint32[7] memory mints = stakedBTCTroveMgr.getTotalMints(week);
-        assertEq(mints[day], INIT_MIN_NET_DEBT / VOLUME_MULTIPLIER);
+        uint256[7] memory mints = stakedBTCTroveMgr.getTotalMints(week);
+        assertEq(mints[day], INIT_MIN_NET_DEBT + INIT_GAS_COMPENSATION);
 
         assertEq(stakedBTCTroveMgr.getTroveFromTroveOwnersArray(0), users.owner);
 

--- a/test/foundry/core/BorrowerOperationsTest.t.sol
+++ b/test/foundry/core/BorrowerOperationsTest.t.sol
@@ -26,7 +26,6 @@ contract BorrowerOperationsTest is StabilityPoolTest {
     // non-public copied from TroveManager.sol
     uint256 internal constant TM_INTEREST_PRECISION = 1e27;
     uint256 internal constant TM_SECONDS_IN_YEAR = 365 days;
-    uint256 internal constant VOLUME_MULTIPLIER = 1e20;
 
     // since owner opens an initial trove, don't want to revert
     // during fuzz tests for trying to open more debt than allowed


### PR DESCRIPTION
-  Removed `VOLUME_MULTIPLIER` and updated the test logic to directly verify that the daily minted debt in the `mints` array matches the sum of `INIT_MIN_NET_DEBT` and `INIT_GAS_COMPENSATION`, ensuring accurate debt tracking and inclusion of gas compensation without scaling adjustments.
![Screenshot 2025-01-21 204006](https://github.com/user-attachments/assets/aab58050-2ee7-408a-9328-62029746d303)
![Screenshot 2025-01-21 204844](https://github.com/user-attachments/assets/9275c4ef-dcfa-454d-a907-e576c6c435f0)
