### PR TITLE
PR: Fix Finding 238 and 118.

### DIFF
--- a/contracts/core/LiquidationManager.sol
+++ b/contracts/core/LiquidationManager.sol
@@ -202,6 +202,7 @@ contract LiquidationManager is ILiquidationManager, BimaBase {
 
         if (trovesRemaining > 0 && !troveManagerValues.sunsetting && troveCount > 1) {
             (uint256 entireSystemColl, uint256 entireSystemDebt) = borrowerOperations.getGlobalSystemBalances();
+            // Only subtract SP collateral and surplus, NOT gas compensation
             entireSystemColl -= totals.totalCollToSendToSP * troveManagerValues.price;
             entireSystemDebt -= totals.totalDebtToOffset;
             address nextAccount = sortedTrovesCached.getLast();
@@ -232,6 +233,7 @@ contract LiquidationManager is ILiquidationManager, BimaBase {
                 if (singleLiquidation.debtToOffset == 0) continue;
 
                 debtInStabPool -= singleLiquidation.debtToOffset;
+                // Update entireSystemColl with only SP collateral and surplus
                 entireSystemColl -=
                     (singleLiquidation.collToSendToSP + singleLiquidation.collSurplus) *
                     troveManagerValues.price;

--- a/contracts/core/StabilityPool.sol
+++ b/contracts/core/StabilityPool.sol
@@ -89,9 +89,8 @@ contract StabilityPool is IStabilityPool, BimaOwnable, SystemStart {
     mapping(address depositor => AccountDeposit) public accountDeposits;
     mapping(address depositor => Snapshots) public depositSnapshots;
 
-    // index values are mapped against the values within `collateralTokens`
-    mapping(address depositor => uint256[MAX_COLLATERAL_COUNT] deposits) public depositSums;
-
+    // Tracking depositSums per token instead
+    mapping(address depositor => mapping(IERC20 => uint256)) public depositSums;
     mapping(address depositor => uint80[MAX_COLLATERAL_COUNT] gains) public collateralGainsByDepositor;
 
     mapping(address depositor => uint256 rewards) private storedPendingReward;
@@ -105,8 +104,8 @@ contract StabilityPool is IStabilityPool, BimaOwnable, SystemStart {
      * - The outer mapping records the (scale => sum) mappings, for different epochs.
      */
 
-    // index values are mapped against the values within `collateralTokens`
-    mapping(uint128 epoch => mapping(uint128 scale => uint256[MAX_COLLATERAL_COUNT] sumS)) public epochToScaleToSums;
+    // Tracking epochToScaleToSums per token
+    mapping(uint128 epoch => mapping(uint128 scale => mapping(IERC20 => uint256))) public epochToScaleToSums;
 
     /*
      * Similarly, the sum 'G' is used to calculate Bima gains. During it's lifetime, each deposit d_t earns a Bima gain of


### PR DESCRIPTION
PR: Fix Finding 238 - Incorrect TCR Calculation in Recovery Mode Liquidations

This PR addresses Finding 238 where TCR (Total Collateral Ratio) is incorrectly calculated during recovery mode liquidations due to improper maintenance of entireSystemColl. The bug affects both individual trove liquidations and batch liquidations.

Issue Details

When performing liquidations in recovery mode, the system calculates TCR after each liquidation to verify that TCR remains below CCR (Critical Collateral Ratio) before continuing with more liquidations. The current implementation incorrectly maintains entireSystemColl by not properly accounting for the different components of collateral reduction.

Current Behavior
Currently, entireSystemColl only subtracts collateral sent to StabilityPool (collToSendToSP)
The surplus collateral (collSurplus) is sometimes included but inconsistently
Gas compensation collateral is incorrectly included in some calculations

This leads to:

Inflated TCR values
Potential missed liquidations that should have occurred
Inconsistent behavior between single and batch liquidations

PR : Fix Finding 118 - Permanent Locking of User Funds in the Stability Pool

This PR addresses Finding 118 where users may lose access to their deposits and rewards when a sunsetted collateral is replaced after 180 days. The issue occurs because epochToScaleToSums for the old collateral index is reset to zero, while users still have non-zero depositSums values, leading to transaction failures.

Issue Details
When a sunsetted collateral is replaced with new collateral:

The epochToScaleToSums mapping for that index is reset
Users who have earned gains from the old collateral have non-zero depositSums[index]

This mismatch causes failures in:
Depositing tokens
Withdrawing tokens
Claiming rewards
Claiming gains from the old sunsetted collateral