### PR TITLE
#9 fixed 

### DIFF
--- a/contracts/core/PriceFeed.sol
+++ b/contracts/core/PriceFeed.sol
@@ -57,8 +57,8 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     // Used to convert a chainlink price answer to an 18-digit precision uint
     uint256 public constant TARGET_DIGITS = 18;
 
-    // Responses are considered stale this many seconds after the oracle's heartbeat
-    uint256 public constant RESPONSE_TIMEOUT_BUFFER = 1 hours;
+    // Max heartbeat 
+    uint256 private constant MAX_HEARTBEAT = 86400;
 
     // Maximum deviation allowed between two consecutive Chainlink oracle prices. 18-digit precision.
     uint256 public constant MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND = 5e17; // 50%
@@ -91,7 +91,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
         uint8 sharePriceDecimals,
         bool _isEthIndexed
     ) public onlyOwner {
-        if (_heartbeat > 86400) revert PriceFeed__HeartbeatOutOfBoundsError();
+        if (_heartbeat > MAX_HEARTBEAT) revert PriceFeed__HeartbeatOutOfBoundsError();
         IAggregatorV3Interface newFeed = IAggregatorV3Interface(_chainlinkOracle);
         (FeedResponse memory currResponse, FeedResponse memory prevResponse, ) = _fetchFeedResponses(newFeed, 0);
 
@@ -215,7 +215,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     }
 
     function _isPriceStale(uint256 _priceTimestamp, uint256 _heartbeat) internal view returns (bool isPriceStale) {
-        isPriceStale = block.timestamp - _priceTimestamp > _heartbeat + RESPONSE_TIMEOUT_BUFFER;
+           isPriceStale = block.timestamp - _priceTimestamp > _heartbeat;
     }
 
     function _isFeedWorking(

--- a/contracts/core/PriceFeed.sol
+++ b/contracts/core/PriceFeed.sol
@@ -58,7 +58,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     uint256 public constant TARGET_DIGITS = 18;
 
     // Max heartbeat 
-    uint256 private constant MAX_HEARTBEAT = 86400;
+    uint256 public constant MAX_HEARTBEAT = 86400;
 
     // Maximum deviation allowed between two consecutive Chainlink oracle prices. 18-digit precision.
     uint256 public constant MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND = 5e17; // 50%

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -18,7 +18,7 @@ interface IPriceFeed is IBimaOwnable {
 
     function MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND() external view returns (uint256);
 
-    function RESPONSE_TIMEOUT_BUFFER() external view returns (uint256);
+    
 
     function TARGET_DIGITS() external view returns (uint256);
 

--- a/test/foundry/core/PriceFeedTest.t.sol
+++ b/test/foundry/core/PriceFeedTest.t.sol
@@ -9,6 +9,9 @@ import {MockOracle} from "../../../contracts/mock/MockOracle.sol";
 
 // forge
 import {console} from "forge-std/console.sol";
+import {PriceFeed} from "../../../contracts/core/PriceFeed.sol";
+import "forge-std/Test.sol";
+  
 
 error PriceFeed__FeedFrozenError(address token);
 error PriceFeed__InvalidFeedResponseError(address token);
@@ -17,16 +20,17 @@ error PriceFeed__HeartbeatOutOfBoundsError();
 
 contract PriceFeedTest is TestSetup {
     MockOracle mockOracle2;
+   
 
-  // Max heartbeat 
-    uint256 public constant MAX_HEARTBEAT = 86400;
 
     function setUp() public virtual override {
         super.setUp();
 
         mockOracle2 = new MockOracle();
+       
+   
     }
-
+   
     function test_setOracle_invalidFeedResponse() external {
         vm.startPrank(users.owner);
 
@@ -52,7 +56,7 @@ contract PriceFeedTest is TestSetup {
     }
 
     function testFuzz_setOracle_frozenFeed(uint32 _heartbeat, uint16 _delta) external {
-        vm.assume(_heartbeat <= MAX_HEARTBEAT);
+        vm.assume(_heartbeat <= priceFeed.MAX_HEARTBEAT());
         vm.assume(_delta > 0);
 
         vm.startPrank(users.owner);
@@ -89,8 +93,8 @@ contract PriceFeedTest is TestSetup {
     }
 
     function testFuzz_setOracle_validHeartbeat(uint32 _heartbeat, uint16 _delta) external {
-    // Test for _heartbeat <= MAX_HEARTBEAT
-    vm.assume(_heartbeat <= MAX_HEARTBEAT);
+    // Test for _heartbeat <= priceFeed.MAX_HEARTBEAT()
+    vm.assume(_heartbeat <= priceFeed.MAX_HEARTBEAT());
 
     vm.assume(_delta > 0);
 
@@ -102,8 +106,8 @@ contract PriceFeedTest is TestSetup {
 }
 
 function testFuzz_setOracle_invalidHeartbeat(uint32 _heartbeat, uint16 _delta) external {
-    // Test for _heartbeat > MAX_HEARTBEAT
-    vm.assume(_heartbeat > MAX_HEARTBEAT);
+    // Test for _heartbeat > priceFeed.MAX_HEARTBEAT()
+    vm.assume(_heartbeat > priceFeed.MAX_HEARTBEAT());
 
     vm.assume(_delta > 0);
 

--- a/test/foundry/core/PriceFeedTest.t.sol
+++ b/test/foundry/core/PriceFeedTest.t.sol
@@ -13,9 +13,13 @@ import {console} from "forge-std/console.sol";
 error PriceFeed__FeedFrozenError(address token);
 error PriceFeed__InvalidFeedResponseError(address token);
 error PriceFeed__UnknownFeedError(address token);
+error PriceFeed__HeartbeatOutOfBoundsError();
 
 contract PriceFeedTest is TestSetup {
     MockOracle mockOracle2;
+
+  // Max heartbeat 
+    uint256 public constant MAX_HEARTBEAT = 86400;
 
     function setUp() public virtual override {
         super.setUp();
@@ -48,7 +52,7 @@ contract PriceFeedTest is TestSetup {
     }
 
     function testFuzz_setOracle_frozenFeed(uint32 _heartbeat, uint16 _delta) external {
-        vm.assume(_heartbeat <= 86400);
+        vm.assume(_heartbeat <= MAX_HEARTBEAT);
         vm.assume(_delta > 0);
 
         vm.startPrank(users.owner);
@@ -56,8 +60,8 @@ contract PriceFeedTest is TestSetup {
         mockOracle2.setResponse(
             2,
             60_000e8,
-            block.timestamp - _heartbeat - priceFeed.RESPONSE_TIMEOUT_BUFFER() - _delta,
-            block.timestamp - _heartbeat - priceFeed.RESPONSE_TIMEOUT_BUFFER() - _delta,
+            block.timestamp - _heartbeat  - _delta,
+            block.timestamp - _heartbeat  - _delta,
             2
         );
 
@@ -83,4 +87,32 @@ contract PriceFeedTest is TestSetup {
 
         assertEq(priceFeed.fetchPrice(address(stakedBTC)), 60_000e18);
     }
+
+    function testFuzz_setOracle_validHeartbeat(uint32 _heartbeat, uint16 _delta) external {
+    // Test for _heartbeat <= MAX_HEARTBEAT
+    vm.assume(_heartbeat <= MAX_HEARTBEAT);
+
+    vm.assume(_delta > 0);
+
+    vm.startPrank(users.owner);
+
+    mockOracle2.setResponse(2, 60_000e8, block.timestamp, block.timestamp, 2);
+
+    priceFeed.setOracle(address(stakedBTC), address(mockOracle2), _heartbeat, bytes4(0x00000000), 18, false);
+}
+
+function testFuzz_setOracle_invalidHeartbeat(uint32 _heartbeat, uint16 _delta) external {
+    // Test for _heartbeat > MAX_HEARTBEAT
+    vm.assume(_heartbeat > MAX_HEARTBEAT);
+
+    vm.assume(_delta > 0);
+
+    vm.startPrank(users.owner);
+
+    mockOracle2.setResponse(2, 60_000e8, block.timestamp, block.timestamp, 2);
+
+    vm.expectRevert(abi.encodeWithSelector(PriceFeed__HeartbeatOutOfBoundsError.selector));
+    priceFeed.setOracle(address(stakedBTC), address(mockOracle2), _heartbeat, bytes4(0x00000000), 18, false);
+}
+
 }

--- a/test/foundry/core/PriceFeedTest.t.sol
+++ b/test/foundry/core/PriceFeedTest.t.sol
@@ -56,6 +56,7 @@ contract PriceFeedTest is TestSetup {
     }
 
     function testFuzz_setOracle_frozenFeed(uint32 _heartbeat, uint16 _delta) external {
+        
         vm.assume(_heartbeat <= priceFeed.MAX_HEARTBEAT());
         vm.assume(_delta > 0);
 

--- a/test/foundry/wrappers/StorkOracleWrapperMocked.t.sol
+++ b/test/foundry/wrappers/StorkOracleWrapperMocked.t.sol
@@ -117,7 +117,7 @@ contract StorkOracleWrapperMockedTest is TestSetup {
 
         priceFeed.setOracle(address(collateral), address(storkOracleWrapper), heartbeat, bytes4(0x00000000), 18, false);
 
-        skip(heartbeat + priceFeed.RESPONSE_TIMEOUT_BUFFER() + 1);
+        skip(heartbeat  + 1);
 
         vm.expectRevert();
         priceFeed.fetchPrice(address(collateral));


### PR DESCRIPTION
**Finding 9 fixed :** 

Removed the RESPONSE_TIMEOUT_BUFFER variable in the PriceFeed contract.
Replaced the hardcoded 86400 value in setOracle function with a global variable MAX_HEARTBEAT.
Ran the forge tests after making changes, confirmed all PriceFeed tests pass.
Added a fuzz test to check when the heartbeat is set to a value less than MAX_HEARTBEAT, and ensured it passes.
Added a fuzz test to check when the heartbeat exceeds MAX_HEARTBEAT, and ensured it passes.
![Screenshot 2025-01-27 173940](https://github.com/user-attachments/assets/f1814d07-e8fa-4185-b1b2-18d43f2d09fc)
![Screenshot 2025-01-27 174223](https://github.com/user-attachments/assets/8c9fb06e-44ee-44b8-9fcc-08df1d01bf50)

