### PR TITLE
#9 Removed the RESPONSE_TIMEOUT_BUFFER variable in the PriceFeed contract.

### DIFF
--- a/contracts/core/PriceFeed.sol
+++ b/contracts/core/PriceFeed.sol
@@ -57,8 +57,8 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     // Used to convert a chainlink price answer to an 18-digit precision uint
     uint256 public constant TARGET_DIGITS = 18;
 
-    // Responses are considered stale this many seconds after the oracle's heartbeat
-    uint256 public constant RESPONSE_TIMEOUT_BUFFER = 1 hours;
+    //  Max heartbeat 
+    uint256 public constant MAX_HEARTBEAT = 86400;
 
     // Maximum deviation allowed between two consecutive Chainlink oracle prices. 18-digit precision.
     uint256 public constant MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND = 5e17; // 50%
@@ -91,7 +91,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
         uint8 sharePriceDecimals,
         bool _isEthIndexed
     ) public onlyOwner {
-        if (_heartbeat > 86400) revert PriceFeed__HeartbeatOutOfBoundsError();
+        if (_heartbeat > MAX_HEARTBEAT) revert PriceFeed__HeartbeatOutOfBoundsError();
         IAggregatorV3Interface newFeed = IAggregatorV3Interface(_chainlinkOracle);
         (FeedResponse memory currResponse, FeedResponse memory prevResponse, ) = _fetchFeedResponses(newFeed, 0);
 
@@ -215,7 +215,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     }
 
     function _isPriceStale(uint256 _priceTimestamp, uint256 _heartbeat) internal view returns (bool isPriceStale) {
-        isPriceStale = block.timestamp - _priceTimestamp > _heartbeat + RESPONSE_TIMEOUT_BUFFER;
+         isPriceStale = block.timestamp - _priceTimestamp > _heartbeat;
     }
 
     function _isFeedWorking(

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -18,7 +18,6 @@ interface IPriceFeed is IBimaOwnable {
 
     function MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND() external view returns (uint256);
 
-    function RESPONSE_TIMEOUT_BUFFER() external view returns (uint256);
 
     function TARGET_DIGITS() external view returns (uint256);
 

--- a/test/foundry/wrappers/StorkOracleWrapperMocked.t.sol
+++ b/test/foundry/wrappers/StorkOracleWrapperMocked.t.sol
@@ -117,7 +117,7 @@ contract StorkOracleWrapperMockedTest is TestSetup {
 
         priceFeed.setOracle(address(collateral), address(storkOracleWrapper), heartbeat, bytes4(0x00000000), 18, false);
 
-        skip(heartbeat + priceFeed.RESPONSE_TIMEOUT_BUFFER() + 1);
+         skip(heartbeat  + 1);
 
         vm.expectRevert();
         priceFeed.fetchPrice(address(collateral));


### PR DESCRIPTION
Removed the RESPONSE_TIMEOUT_BUFFER variable in the PriceFeed contract.
Replaced the hardcoded 86400 value in setOracle function with a global variable MAX_HEARTBEAT.
Ran the forge tests after making changes, confirmed all PriceFeed tests pass.
Added a fuzz test to check when the heartbeat is set to a value less than MAX_HEARTBEAT, and ensured it passes.
Added a fuzz test to check when the heartbeat exceeds MAX_HEARTBEAT, and ensured it passes.

![image](https://github.com/user-attachments/assets/8af6cacd-f100-40a5-ac64-0c09d8875404)
![Screenshot 2025-01-28 202828](https://github.com/user-attachments/assets/7f51cae2-fa06-48d9-bc94-3363a0ef1bb5)
