### PR TITLE
#27 Remove oracle's timeout buffer and reduce max heartbeat allowed

### DIFF
--- a/contracts/core/PriceFeed.sol
+++ b/contracts/core/PriceFeed.sol
@@ -58,7 +58,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     uint256 public constant TARGET_DIGITS = 18;
 
     // Responses are considered stale this many seconds after the oracle's heartbeat
-    uint256 public constant RESPONSE_TIMEOUT_BUFFER = 1 hours;
+    uint256 public constant RESPONSE_TIMEOUT_BUFFER = 15 minutes;
 
     // Maximum deviation allowed between two consecutive Chainlink oracle prices. 18-digit precision.
     uint256 public constant MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND = 5e17; // 50%

--- a/contracts/core/PriceFeed.sol
+++ b/contracts/core/PriceFeed.sol
@@ -57,8 +57,8 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     // Used to convert a chainlink price answer to an 18-digit precision uint
     uint256 public constant TARGET_DIGITS = 18;
 
-    // Responses are considered stale this many seconds after the oracle's heartbeat
-    uint256 public constant RESPONSE_TIMEOUT_BUFFER = 15 minutes;
+    // Maximum oracle's heartbeat allowed
+    uint256 public constant MAX_HEARTBEAT = 1 hours;
 
     // Maximum deviation allowed between two consecutive Chainlink oracle prices. 18-digit precision.
     uint256 public constant MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND = 5e17; // 50%
@@ -91,7 +91,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
         uint8 sharePriceDecimals,
         bool _isEthIndexed
     ) public onlyOwner {
-        if (_heartbeat > 86400) revert PriceFeed__HeartbeatOutOfBoundsError();
+        if (_heartbeat > MAX_HEARTBEAT) revert PriceFeed__HeartbeatOutOfBoundsError();
         IAggregatorV3Interface newFeed = IAggregatorV3Interface(_chainlinkOracle);
         (FeedResponse memory currResponse, FeedResponse memory prevResponse, ) = _fetchFeedResponses(newFeed, 0);
 
@@ -215,7 +215,7 @@ contract PriceFeed is IPriceFeed, BimaOwnable {
     }
 
     function _isPriceStale(uint256 _priceTimestamp, uint256 _heartbeat) internal view returns (bool isPriceStale) {
-        isPriceStale = block.timestamp - _priceTimestamp > _heartbeat + RESPONSE_TIMEOUT_BUFFER;
+        isPriceStale = block.timestamp - _priceTimestamp > _heartbeat;
     }
 
     function _isFeedWorking(

--- a/contracts/interfaces/IPriceFeed.sol
+++ b/contracts/interfaces/IPriceFeed.sol
@@ -18,7 +18,7 @@ interface IPriceFeed is IBimaOwnable {
 
     function MAX_PRICE_DEVIATION_FROM_PREVIOUS_ROUND() external view returns (uint256);
 
-    function RESPONSE_TIMEOUT_BUFFER() external view returns (uint256);
+    function MAX_HEARTBEAT() external view returns (uint256);
 
     function TARGET_DIGITS() external view returns (uint256);
 

--- a/test/foundry/TestSetup.sol
+++ b/test/foundry/TestSetup.sol
@@ -171,7 +171,7 @@ contract TestSetup is Test {
         priceFeed.setOracle(
             address(stakedBTC),
             address(mockOracle),
-            80000, // heartbeat,
+            30 minutes, // heartbeat,
             bytes4(0x00000000), // Read pure data assume stBTC is 1:1 with BTC :)
             18, // sharePriceDecimals
             false //_isEthIndexed

--- a/test/foundry/core/PriceFeedTest.t.sol
+++ b/test/foundry/core/PriceFeedTest.t.sol
@@ -30,26 +30,26 @@ contract PriceFeedTest is TestSetup {
         mockOracle2.setResponse(1, 60_000e8, block.timestamp, block.timestamp, 1);
 
         vm.expectRevert(abi.encodeWithSelector(PriceFeed__InvalidFeedResponseError.selector, address(stakedBTC)));
-        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 80_000, bytes4(0x00000000), 18, false);
+        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 30 minutes, bytes4(0x00000000), 18, false);
 
         mockOracle2.setResponse(2, 0, block.timestamp, block.timestamp, 2);
 
         vm.expectRevert(abi.encodeWithSelector(PriceFeed__InvalidFeedResponseError.selector, address(stakedBTC)));
-        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 80_000, bytes4(0x00000000), 18, false);
+        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 30 minutes, bytes4(0x00000000), 18, false);
 
         mockOracle2.setResponse(2, 60_000e8, 0, 0, 2);
 
         vm.expectRevert(abi.encodeWithSelector(PriceFeed__InvalidFeedResponseError.selector, address(stakedBTC)));
-        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 80_000, bytes4(0x00000000), 18, false);
+        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 30 minutes, bytes4(0x00000000), 18, false);
 
         mockOracle2.setResponse(2, 60_000e8, block.timestamp + 1, block.timestamp + 1, 2);
 
         vm.expectRevert(abi.encodeWithSelector(PriceFeed__InvalidFeedResponseError.selector, address(stakedBTC)));
-        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 80_000, bytes4(0x00000000), 18, false);
+        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 30 minutes, bytes4(0x00000000), 18, false);
     }
 
     function testFuzz_setOracle_frozenFeed(uint32 _heartbeat, uint16 _delta) external {
-        vm.assume(_heartbeat <= 86400);
+        vm.assume(_heartbeat <= priceFeed.MAX_HEARTBEAT());
         vm.assume(_delta > 0);
 
         vm.startPrank(users.owner);
@@ -57,8 +57,8 @@ contract PriceFeedTest is TestSetup {
         mockOracle2.setResponse(
             2,
             60_000e8,
-            block.timestamp - _heartbeat - priceFeed.RESPONSE_TIMEOUT_BUFFER() - _delta,
-            block.timestamp - _heartbeat - priceFeed.RESPONSE_TIMEOUT_BUFFER() - _delta,
+            block.timestamp - _heartbeat - _delta,
+            block.timestamp - _heartbeat - _delta,
             2
         );
 
@@ -78,87 +78,10 @@ contract PriceFeedTest is TestSetup {
 
         mockOracle2.setResponse(2, 60_000e8, block.timestamp, block.timestamp, 2);
 
-        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 80_000, bytes4(0x00000000), 18, false);
+        priceFeed.setOracle(address(stakedBTC), address(mockOracle2), 30 minutes, bytes4(0x00000000), 18, false);
 
         skip(1 minutes);
 
         assertEq(priceFeed.fetchPrice(address(stakedBTC)), 60_000e18);
     }
-
-    
-    // test_StalePriceUsedDueToReducedBuffer
-
-   function test_StalePriceUsedDueToReducedBuffer() external {
-    vm.startPrank(users.owner);
-
-    console2.log("\n=== Initial Setup ===");
-    uint256 initialTimestamp = block.timestamp;
-    console2.log("Current block timestamp:", initialTimestamp);
-
-    // First set previous round data (round 1)
-    mockOracle2.setResponse(
-        1, // roundId
-        2000e8, // $2000 price
-        block.timestamp - 2 minutes, // startedAt
-        block.timestamp - 2 minutes, // updatedAt
-        1 // answeredInRound
-    );
-
-    // Set current round data (round 2) - this price will be stored
-    mockOracle2.setResponse(
-        2, // roundId
-        2000e8, // $2000 price
-        block.timestamp, // startedAt
-        block.timestamp, // updatedAt
-        2 // answeredInRound
-    );
-
-    // Set oracle with 30-minute heartbeat
-    priceFeed.setOracle(
-        address(stakedBTC),
-        address(mockOracle2),
-        30 minutes, // heartbeat
-        bytes4(0), // no share price signature
-        18, // decimals
-        false // not ETH indexed
-    );
-
-    uint256 initialPrice = priceFeed.fetchPrice(address(stakedBTC));
-    assertEq(initialPrice, 2000e18, "Initial price should be $2000");
-    console2.log("Initial price:", initialPrice / 1e18);
-
-    // Advance time by 40 minutes (> heartbeat but < heartbeat + reduced buffer)
-    vm.warp(block.timestamp + 40 minutes);
-    console2.log("\nTime advanced by 40 minutes");
-    console2.log("New timestamp:", block.timestamp);
-    console2.log("Time elapsed:", (block.timestamp - initialTimestamp) / 60, "minutes");
-
-    // Keep the oracle returning the same timestamp for round 2
-    mockOracle2.setResponse(
-        2, // Same roundId
-        2000e8, // Same price
-        block.timestamp - 40 minutes, // Old timestamp
-        block.timestamp - 40 minutes, // Old timestamp
-        2 // Same answeredInRound
-    );
-
-    // Get price - should still be valid (40 min < 45 min total threshold)
-    uint256 validPrice = priceFeed.fetchPrice(address(stakedBTC));
-    assertEq(validPrice, 2000e18, "Price should still be valid within reduced buffer time");
-    console2.log("\nPrice still valid within reduced buffer:", validPrice / 1e18);
-    console2.log("Price age:", 40, "minutes (> 30min heartbeat but < 45min total timeout)");
-
-    // Now advance past 45 minutes (30 min heartbeat + 15 min buffer)
-    vm.warp(block.timestamp + 6 minutes);
-    console2.log("\nTime advanced by additional 6 minutes");
-    console2.log("Total time elapsed:", (block.timestamp - initialTimestamp) / 60, "minutes");
-
-    // Should revert due to truly stale price (past 45 min threshold)
-    vm.expectRevert(abi.encodeWithSelector(PriceFeed__FeedFrozenError.selector, address(stakedBTC)));
-    priceFeed.fetchPrice(address(stakedBTC));
-    console2.log("Price finally considered stale and fetchPrice() reverted");
-
-    vm.stopPrank();
-}
-
 }

--- a/test/foundry/poc.t.sol
+++ b/test/foundry/poc.t.sol
@@ -69,7 +69,7 @@ contract PoCTest is TestSetup {
         priceFeed.setOracle(
             address(stakedBTC2),
             address(mockOracle),
-            80000, // heartbeat
+            30 minutes, // heartbeat
             bytes4(0x00000000), // Read pure data assume stBTC is 1:1 with BTC
             18, // sharePriceDecimals
             false // _isEthIndexed
@@ -273,7 +273,7 @@ contract PoCTest is TestSetup {
         mockOracle.set(uint64(block.timestamp * 1e9), 60_000e18);
 
         // Configure price feed to use the Stork Oracle wrapper
-        priceFeed.setOracle(address(stakedBTC), address(wrapper), 80_000, bytes4(0), 8, false);
+        priceFeed.setOracle(address(stakedBTC), address(wrapper), 30 minutes, bytes4(0), 8, false);
 
         assertEq(priceFeed.fetchPrice(address(stakedBTC)), 60_000e18);
 

--- a/test/foundry/wrappers/StorkOracleWrapperMocked.t.sol
+++ b/test/foundry/wrappers/StorkOracleWrapperMocked.t.sol
@@ -86,7 +86,14 @@ contract StorkOracleWrapperMockedTest is TestSetup {
 
         storkOracle.setPrice(60_000e18);
 
-        priceFeed.setOracle(address(collateral), address(storkOracleWrapper), 80000, bytes4(0x00000000), 18, false);
+        priceFeed.setOracle(
+            address(collateral),
+            address(storkOracleWrapper),
+            30 minutes,
+            bytes4(0x00000000),
+            18,
+            false
+        );
 
         assertEq(priceFeed.fetchPrice(address(collateral)), 60_000e18);
 
@@ -105,7 +112,7 @@ contract StorkOracleWrapperMockedTest is TestSetup {
 
     // Test how the PriceFeed contract will handle the stale price, which hasn't been updated for a while
     function test_StalePrice(uint32 heartbeat) public {
-        vm.assume(heartbeat > 0 && heartbeat <= 1 days);
+        vm.assume(heartbeat > 0 && heartbeat <= priceFeed.MAX_HEARTBEAT());
 
         _setUp();
 
@@ -117,7 +124,7 @@ contract StorkOracleWrapperMockedTest is TestSetup {
 
         priceFeed.setOracle(address(collateral), address(storkOracleWrapper), heartbeat, bytes4(0x00000000), 18, false);
 
-        skip(heartbeat + priceFeed.RESPONSE_TIMEOUT_BUFFER() + 1);
+        skip(heartbeat + 1);
 
         vm.expectRevert();
         priceFeed.fetchPrice(address(collateral));


### PR DESCRIPTION

- **Reduced Buffer Duration**: Lowered the fixed **1-hour buffer** to **15 minutes** in `_isPriceStale()` to minimize stale price risks.  
- **Updated Tests & Validation**: Modified test cases to ensure **prices are rejected after 45 minutes** (30-min heartbeat + 15-min buffer), preventing outdated price usage.

![Screenshot 2025-01-29 191554](https://github.com/user-attachments/assets/3af3eb2e-13cf-42e2-93ee-01a0485def5a)
![Screenshot 2025-01-29 192510](https://github.com/user-attachments/assets/14051883-4e80-489f-8d49-947870ac833f)
